### PR TITLE
Adding to assignment in grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -506,6 +506,7 @@ module.exports = grammar({
 
     assignment: $ => choice(
       prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),
+      prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, "=", $._expression)),
       // TODO
     ),
 
@@ -847,9 +848,23 @@ module.exports = grammar({
                                //       does it seem to be very uncommon to write the safe
                                //       navigation operator 'split up' in Kotlin.
 
-    directly_assignable_expression: $ => choice(
-      $.simple_identifier
-      // TODO
+    _postfix_unary_suffix: $ => choice(
+      $._postfix_unary_operator,
+      $.navigation_suffix
+    ),
+
+    _postfix_unary_expression: $ => prec(
+      PREC.ASSIGNMENT,
+      seq($._primary_expression, repeat($._postfix_unary_suffix))
+    ),
+
+    directly_assignable_expression: $ => prec(
+      PREC.ASSIGNMENT,
+      choice(
+        $._postfix_unary_expression,
+        $.simple_identifier
+        // TODO
+      )
     ),
 
     // ==========

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -1,0 +1,32 @@
+==================
+This Assignment
+==================
+
+class Foo(){
+  var foo = null
+  constructor(bar:Int) {
+    this.foo = bar
+  }
+}
+
+---
+(source_file
+  (class_declaration
+    (type_identifier)
+    (primary_constructor)
+    (class_body
+      (property_declaration
+        (variable_declaration
+          (simple_identifier)))
+      (secondary_constructor
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (statements
+          (assignment
+            (directly_assignable_expression
+              (this_expression)
+              (navigation_suffix
+                (simple_identifier)))
+            (simple_identifier)))))))


### PR DESCRIPTION
Fixes errors where lines like `this.foo = bar` don't parse.

To test: use
```
npx tree-sitter test
```
The `this assignment` test should pass.

_Pad's Comment:_

> 'This is nice, and it might simplify the original grammar of Kotlin, but I'm a bit worried that we deviate now even
> more from the original grammar. Fwcd already deviated from the original grammar a little on how he is handling expressions. I'd rather see us go back to the original spec of Kotlin where there is a directly_assignable_expression,
> and a postfix_unary_operator, etc.'

