### PR TITLE
Small grammar edits

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -122,7 +122,8 @@ module.exports = grammar({
     // start
     source_file: $ => seq(
       optional($.shebang_line),
-      optional(seq(repeat1($.file_annotation), $._semi)),
+      repeat($.file_annotation),
+      //optional(seq(repeat1($.file_annotation), $._semi)),
       optional($.package_header),
       repeat($.import_header),
       repeat(seq($._statement, $._semi))
@@ -543,7 +544,7 @@ module.exports = grammar({
     // generic EOF/newline token
     _semi: $ => /[\r\n]+/,
 
-    _semis: $ => /[\r\n]+/,
+    _semis: $ => /[\r\n;]+/,
 
     assignment: $ => choice(
       prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),

--- a/grammar.js
+++ b/grammar.js
@@ -122,8 +122,7 @@ module.exports = grammar({
     // start
     source_file: $ => seq(
       optional($.shebang_line),
-      repeat($.file_annotation),
-      //optional(seq(repeat1($.file_annotation), $._semi)),
+      optional(seq(repeat1($.file_annotation), $._semi)),
       optional($.package_header),
       repeat($.import_header),
       repeat(seq($._statement, $._semi))
@@ -330,8 +329,8 @@ module.exports = grammar({
       optional(';'),
       choice(
         // TODO: Getter-setter combinations
-        seq(optional($.getter), optional(seq($.setter))),
-        seq(optional($.setter), optional(seq($.getter)))
+        optional($.getter),
+        optional($.setter)
       )
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -122,7 +122,7 @@ module.exports = grammar({
     // start
     source_file: $ => seq(
       optional($.shebang_line),
-      optional(seq(repeat1($.file_annotation), $._semi)),
+      repeat($.file_annotation),
       optional($.package_header),
       repeat($.import_header),
       repeat(seq($._statement, $._semi))
@@ -152,6 +152,7 @@ module.exports = grammar({
     top_level_object: $ => seq($._declaration, optional($._semis)),
 
     type_alias: $ => seq(
+      optional($.modifiers),
       "typealias",
       alias($.simple_identifier, $.type_identifier),
       "=",
@@ -480,8 +481,8 @@ module.exports = grammar({
 
     statements: $ => seq(
       $._statement,
-      repeat(seq($._semis_and_colon, $._statement)),
-      optional($._semis_and_colon),
+      repeat(seq($._semis, $._statement)),
+      optional($._semis),
     ),
 
     _statement: $ => choice(
@@ -544,8 +545,6 @@ module.exports = grammar({
     _semi: $ => /[\r\n]+/,
 
     _semis: $ => /[\r\n]+/,
-
-    _semis_and_colon: $ => choice($._semis, ';'),
 
     assignment: $ => choice(
       prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),
@@ -616,7 +615,9 @@ module.exports = grammar({
 
     elvis_expression: $ => prec.left(PREC.ELVIS, seq($._expression, "?:", $._expression)),
 
-    check_expression: $ => prec.left(PREC.CHECK, seq($._expression, choice($._in_operator, $._is_operator), $._expression)),
+    check_expression: $ => prec.left(PREC.CHECK, seq($._expression, choice(
+      seq($._in_operator, $._expression), 
+      seq($._is_operator, $._type)))),
 
     comparison_expression: $ => prec.left(PREC.COMPARISON, seq($._expression, $._comparison_operator, $._expression)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -330,8 +330,8 @@ module.exports = grammar({
       optional(';'),
       choice(
         // TODO: Getter-setter combinations
-        optional($.getter),
-        optional($.setter)
+        seq(optional($.getter), optional(seq($.setter))),
+        seq(optional($.setter), optional(seq($.getter)))
       )
     )),
 
@@ -481,8 +481,8 @@ module.exports = grammar({
 
     statements: $ => seq(
       $._statement,
-      repeat(seq($._semis, $._statement)),
-      optional($._semis),
+      repeat(seq($._semis_and_colon, $._statement)),
+      optional($._semis_and_colon),
     ),
 
     _statement: $ => choice(
@@ -544,7 +544,9 @@ module.exports = grammar({
     // generic EOF/newline token
     _semi: $ => /[\r\n]+/,
 
-    _semis: $ => /[\r\n;]+/,
+    _semis: $ => /[\r\n]+/,
+
+    _semis_and_colon: $ => choice($._semis, ';'),
 
     assignment: $ => choice(
       prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),
@@ -826,7 +828,7 @@ module.exports = grammar({
 
     range_test: $ => seq($._in_operator, $._expression),
 
-    type_test: $ => seq($._is_operator, $._expression),
+    type_test: $ => seq($._is_operator, $._type),
 
     try_expression: $ => seq(
       "try",

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -10,7 +10,7 @@ class Empty2 {}
 (source_file
   (class_declaration (type_identifier))
   (class_declaration (type_identifier) (class_body)))
- 
+
 ==================
 Class with methods
 ==================
@@ -272,3 +272,32 @@ enum class Color(val rgb: Int) {
             (call_suffix
               (value_arguments
                 (value_argument (integer_literal))))))))))
+
+==================
+Type alias declaration
+==================
+
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+ internal actual typealias CoroutineStackFrame = kotlin.coroutines.jvm.internal.CoroutineStackFrame
+
+ ---
+
+ (source_file
+  (type_alias
+    (modifiers
+      (annotation
+        (constructor_invocation
+          (user_type
+            (type_identifier))
+          (value_arguments
+            (value_argument
+              (line_string_literal)))))
+      (visibility_modifier)
+      (platform_modifier))
+    (type_identifier)
+    (user_type
+      (type_identifier)
+      (type_identifier)
+      (type_identifier)
+      (type_identifier)
+      (type_identifier))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -51,6 +51,30 @@ val y = when(x){
       (when_entry (when_condition (integer_literal))
         (control_structure_body (boolean_literal))))))
 
+=================
+When expression with type arguments
+================
+
+when (this) {
+    is DispatchedCoroutine<*> -> return null
+}
+
+---
+
+(source_file
+  (when_expression
+    (when_subject
+      (this_expression))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier)
+            (type_arguments
+              (type_projection)))))
+      (control_structure_body
+        (jump_expression)))))
+
 ==================
 Value declaration with receiver type
 ==================

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -17,3 +17,33 @@ val x = 4
     (variable_declaration
       (simple_identifier))
     (integer_literal)))
+
+===================
+Multiple file annotations
+===================
+
+@file:JvmMultifileClass
+@file:JvmName("BuildersKt")
+@file:OptIn(ExperimentalContracts::class)
+
+---
+
+(source_file
+  (file_annotation
+    (user_type
+      (type_identifier)))
+  (file_annotation
+    (constructor_invocation
+      (user_type
+        (type_identifier))
+      (value_arguments
+        (value_argument
+          (line_string_literal)))))
+  (file_annotation
+    (constructor_invocation
+      (user_type
+        (type_identifier))
+      (value_arguments
+        (value_argument
+          (callable_reference
+            (type_identifier)))))))

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -17,33 +17,3 @@ val x = 4
     (variable_declaration
       (simple_identifier))
     (integer_literal)))
-
-===================
-Multiple file annotations
-===================
-
-@file:JvmMultifileClass
-@file:JvmName("BuildersKt")
-@file:OptIn(ExperimentalContracts::class)
-
----
-
-(source_file
-  (file_annotation
-    (user_type
-      (type_identifier)))
-  (file_annotation
-    (constructor_invocation
-      (user_type
-        (type_identifier))
-      (value_arguments
-        (value_argument
-          (line_string_literal)))))
-  (file_annotation
-    (constructor_invocation
-      (user_type
-        (type_identifier))
-      (value_arguments
-        (value_argument
-          (callable_reference
-            (type_identifier)))))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -12,3 +12,27 @@ for (value in values) {}
     (simple_identifier)
     (control_structure_body)))
 
+==================
+Statements separated by semicolon
+==================
+
+override fun isDisposed(): Boolean { expectUnreached();  return false }
+
+---
+
+(source_file
+  (function_declaration
+    (modifiers
+      (member_modifier))
+    (simple_identifier)
+    (user_type
+      (type_identifier))
+    (function_body
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))
+        (jump_expression
+          (boolean_literal))))))
+


### PR DESCRIPTION
Changes:
1. Added support for semicolons separating statements with no new line in between them
2. Changed `type_test` to be more similar to kotlin grammar (type instead of expression)

Currently getting 93.865% parsing rate with the multiple file annotations fix that @aryx also has. I took out the changes so that we don't have a conflict during future merges.

_To test:_
run `npx tree-sitter test`