### PR TITLE
New scanner.c to better handle newlines

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,7 @@
       ],
       "sources": [
         "src/parser.c",
+        "src/scanner.c",
         "bindings/node/binding.cc"
       ],
       "cflags_c": [

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -10,14 +10,9 @@ fn main() {
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());

--- a/grammar.js
+++ b/grammar.js
@@ -103,6 +103,10 @@ module.exports = grammar({
     [$.user_type, $.function_type],
   ],
 
+  externals: $ => [
+    $._automatic_semicolon,
+  ],
+
   extras: $ => [
     $.comment,
     /\s+/ // Whitespace
@@ -135,7 +139,8 @@ module.exports = grammar({
       choice(
         seq("[", repeat1($._unescaped_annotation), "]"),
         $._unescaped_annotation
-      )
+      ),
+      $._semi
     ),
 
     package_header: $ => seq("package", $.identifier, $._semi),
@@ -542,9 +547,9 @@ module.exports = grammar({
 
     // See also https://github.com/tree-sitter/tree-sitter/issues/160
     // generic EOF/newline token
-    _semi: $ => /[\r\n]+/,
+    _semi: $ => choice($._automatic_semicolon, ';'),
 
-    _semis: $ => /[\r\n]+/,
+    _semis: $ => choice($._automatic_semicolon, ';'),
 
     assignment: $ => choice(
       prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -18,28 +18,11 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "file_annotation"
-                  }
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_semi"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "file_annotation"
+          }
         },
         {
           "type": "CHOICE",
@@ -134,6 +117,10 @@
               "name": "_unescaped_annotation"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_semi"
         }
       ]
     },
@@ -239,6 +226,18 @@
     "type_alias": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "modifiers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
         {
           "type": "STRING",
           "value": "typealias"
@@ -1161,6 +1160,40 @@
         }
       ]
     },
+    "_receiver_type": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_modifiers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_type_reference"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parenthesized_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "nullable_type"
+            }
+          ]
+        }
+      ]
+    },
     "function_declaration": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -1180,6 +1213,10 @@
             ]
           },
           {
+            "type": "STRING",
+            "value": "fun"
+          },
+          {
             "type": "CHOICE",
             "members": [
               {
@@ -1192,8 +1229,33 @@
             ]
           },
           {
-            "type": "STRING",
-            "value": "fun"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_receiver_type"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "."
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           },
           {
             "type": "SYMBOL",
@@ -1274,34 +1336,38 @@
       ]
     },
     "variable_declaration": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "simple_identifier"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ":"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_type"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "simple_identifier"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ":"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "property_declaration": {
       "type": "PREC_RIGHT",
@@ -1347,8 +1413,46 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "variable_declaration"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_receiver_type"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "."
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "multi_variable_declaration"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -1386,6 +1490,18 @@
                     "name": "property_delegate"
                   }
                 ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ";"
               },
               {
                 "type": "BLANK"
@@ -2025,37 +2141,33 @@
       "value": "?"
     },
     "user_type": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_simple_user_type"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "."
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_simple_user_type"
-                }
-              ]
-            }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_simple_user_type"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_simple_user_type"
+              }
+            ]
           }
-        ]
-      }
+        }
+      ]
     },
     "_simple_user_type": {
       "type": "PREC_RIGHT",
-      "value": 0,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2459,6 +2571,10 @@
               {
                 "type": "SYMBOL",
                 "name": "variable_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "multi_variable_declaration"
               }
             ]
           },
@@ -2565,12 +2681,30 @@
       }
     },
     "_semi": {
-      "type": "PATTERN",
-      "value": "[\\r\\n]+"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_automatic_semicolon"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
     },
     "_semis": {
-      "type": "PATTERN",
-      "value": "[\\r\\n]+"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_automatic_semicolon"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        }
+      ]
     },
     "assignment": {
       "type": "CHOICE",
@@ -2739,7 +2873,7 @@
     },
     "prefix_expression": {
       "type": "PREC_RIGHT",
-      "value": 15,
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2977,18 +3111,32 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_in_operator"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_in_operator"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "_is_operator"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_is_operator"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type"
+                  }
+                ]
               }
             ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_expression"
           }
         ]
       }
@@ -3708,6 +3856,44 @@
         ]
       }
     },
+    "multi_variable_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "variable_declaration"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "variable_declaration"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "lambda_parameters": {
       "type": "SEQ",
       "members": [
@@ -3739,6 +3925,10 @@
         {
           "type": "SYMBOL",
           "name": "variable_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "multi_variable_declaration"
         }
       ]
     },
@@ -4140,7 +4330,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_expression"
+          "name": "_type"
         }
       ]
     },
@@ -4247,7 +4437,7 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "PREC_LEFT",
+          "type": "PREC_RIGHT",
           "value": 0,
           "content": {
             "type": "SEQ",
@@ -4264,7 +4454,7 @@
           }
         },
         {
-          "type": "PREC_LEFT",
+          "type": "PREC_RIGHT",
           "value": 0,
           "content": {
             "type": "SEQ",
@@ -5753,11 +5943,7 @@
       "members": [
         {
           "type": "STRING",
-          "value": "\\"
-        },
-        {
-          "type": "STRING",
-          "value": "u"
+          "value": "\\u"
         },
         {
           "type": "PATTERN",
@@ -5872,10 +6058,42 @@
     [
       "type_arguments",
       "_comparison_operator"
+    ],
+    [
+      "_statement",
+      "prefix_expression"
+    ],
+    [
+      "_statement",
+      "prefix_expression",
+      "modifiers"
+    ],
+    [
+      "prefix_expression",
+      "when_subject"
+    ],
+    [
+      "prefix_expression",
+      "value_argument"
+    ],
+    [
+      "user_type"
+    ],
+    [
+      "user_type",
+      "anonymous_function"
+    ],
+    [
+      "user_type",
+      "function_type"
     ]
   ],
-  "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_automatic_semicolon"
+    }
+  ],
   "inline": [],
   "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -951,6 +951,10 @@
           "named": true
         },
         {
+          "type": "function_type",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -999,11 +1003,19 @@
           "named": true
         },
         {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
         {
           "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_type",
           "named": true
         },
         {
@@ -1043,7 +1055,15 @@
           "named": true
         },
         {
+          "type": "type_modifiers",
+          "named": true
+        },
+        {
           "type": "unsigned_literal",
+          "named": true
+        },
+        {
+          "type": "user_type",
           "named": true
         },
         {
@@ -3362,6 +3382,10 @@
           "named": true
         },
         {
+          "type": "multi_variable_declaration",
+          "named": true
+        },
+        {
           "type": "multiplicative_expression",
           "named": true
         },
@@ -5057,6 +5081,10 @@
       "required": true,
       "types": [
         {
+          "type": "multi_variable_declaration",
+          "named": true
+        },
+        {
           "type": "variable_declaration",
           "named": true
         }
@@ -5171,6 +5199,21 @@
         },
         {
           "type": "interpolated_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "multi_variable_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "variable_declaration",
           "named": true
         }
       ]
@@ -6431,6 +6474,10 @@
           "named": true
         },
         {
+          "type": "multi_variable_declaration",
+          "named": true
+        },
+        {
           "type": "multiplicative_expression",
           "named": true
         },
@@ -6439,11 +6486,19 @@
           "named": true
         },
         {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
         {
           "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_type",
           "named": true
         },
         {
@@ -6495,11 +6550,19 @@
           "named": true
         },
         {
+          "type": "type_modifiers",
+          "named": true
+        },
+        {
           "type": "type_parameters",
           "named": true
         },
         {
           "type": "unsigned_literal",
+          "named": true
+        },
+        {
+          "type": "user_type",
           "named": true
         },
         {
@@ -7929,6 +7992,10 @@
           "named": true
         },
         {
+          "type": "modifiers",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -8172,167 +8239,27 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
-          "type": "additive_expression",
+          "type": "function_type",
           "named": true
         },
         {
-          "type": "anonymous_function",
+          "type": "nullable_type",
           "named": true
         },
         {
-          "type": "as_expression",
+          "type": "parenthesized_type",
           "named": true
         },
         {
-          "type": "bin_literal",
+          "type": "type_modifiers",
           "named": true
         },
         {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "line_string_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
-          "named": true
-        },
-        {
-          "type": "multi_line_string_literal",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
-          "named": true
-        },
-        {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "when_expression",
+          "type": "user_type",
           "named": true
         }
       ]
@@ -9372,7 +9299,7 @@
     "named": false
   },
   {
-    "type": "\\",
+    "type": "\\u",
     "named": false
   },
   {
@@ -9422,10 +9349,6 @@
   {
     "type": "class",
     "named": false
-  },
-  {
-    "type": "comment",
-    "named": true
   },
   {
     "type": "companion",
@@ -9693,10 +9616,6 @@
   },
   {
     "type": "typealias",
-    "named": false
-  },
-  {
-    "type": "u",
     "named": false
   },
   {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,89 @@
+#include <tree_sitter/parser.h>
+#include <wctype.h>
+
+// Mostly a copy paste of tree-sitter-javascript/src/scanner.c
+
+enum TokenType {
+  AUTOMATIC_SEMICOLON,
+};
+
+void *tree_sitter_kotlin_external_scanner_create() { return NULL; }
+void tree_sitter_kotlin_external_scanner_destroy(void *p) {}
+void tree_sitter_kotlin_external_scanner_reset(void *p) {}
+unsigned tree_sitter_kotlin_external_scanner_serialize(void *p, char *buffer) { return 0; }
+void tree_sitter_kotlin_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
+
+static void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+static bool scan_whitespace_and_comments(TSLexer *lexer) {
+  for (;;) {
+    while (iswspace(lexer->lookahead)) {
+      advance(lexer);
+    }
+
+    if (lexer->lookahead == '/') {
+      advance(lexer);
+
+      if (lexer->lookahead == '/') {
+        advance(lexer);
+        while (lexer->lookahead != 0 && lexer->lookahead != '\n') {
+          advance(lexer);
+        }
+      } else if (lexer->lookahead == '*') {
+        advance(lexer);
+        while (lexer->lookahead != 0) {
+          if (lexer->lookahead == '*') {
+            advance(lexer);
+            if (lexer->lookahead == '/') {
+              advance(lexer);
+              break;
+            }
+          } else {
+            advance(lexer);
+          }
+        }
+      } else {
+        return false;
+      }
+    } else {
+      return true;
+    }
+  }
+}
+
+
+bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
+                                                  const bool *valid_symbols) {
+  if (!valid_symbols[AUTOMATIC_SEMICOLON]) return false;
+  lexer->result_symbol = AUTOMATIC_SEMICOLON;
+  lexer->mark_end(lexer);
+
+  for (;;) {
+    if (!iswspace(lexer->lookahead)) return false;
+    if (lexer->lookahead == '\n') break;
+    // other whitespace (not newline)
+    advance(lexer);
+  }
+  // consume the '\n' from the break
+  advance(lexer);
+
+  if (!scan_whitespace_and_comments(lexer)) return false;
+
+  switch (lexer->lookahead) {
+    // specific to Kotlin
+    case '{': // ex: function body defined on next line after decl
+
+    // cases also in tree-sitter-javascript/src/scanner.c
+    case '.': // ex: method-chain calls on next line
+    case ':': // ex: inheritance clause defined on next line
+    case '=': // ex: fun/val definition on next line (or == binop)
+    case '?': // ex: elvis operator ?: on next line
+    case '^': // ex: binary operator between 2 exprs
+    case '|': // ex: binary operator between 2 exprs
+    case '&': // ex: binary operator between 2 exprs
+
+      return false;
+  }
+
+  return true;
+}

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,6 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
@@ -32,10 +30,11 @@ typedef struct {
   uint16_t length;
 } TSFieldMapSlice;
 
+typedef uint16_t TSStateId;
+
 typedef struct {
-  bool visible;
-  bool named;
-  bool supertype;
+  bool visible : 1;
+  bool named : 1;
 } TSSymbolMetadata;
 
 typedef struct TSLexer TSLexer;
@@ -57,21 +56,21 @@ typedef enum {
   TSParseActionTypeRecover,
 } TSParseActionType;
 
-typedef union {
-  struct {
-    uint8_t type;
-    TSStateId state;
-    bool extra;
-    bool repetition;
-  } shift;
-  struct {
-    uint8_t type;
-    uint8_t child_count;
-    TSSymbol symbol;
-    int16_t dynamic_precedence;
-    uint16_t production_id;
-  } reduce;
-  uint8_t type;
+typedef struct {
+  union {
+    struct {
+      TSStateId state;
+      bool extra : 1;
+      bool repetition : 1;
+    } shift;
+    struct {
+      TSSymbol symbol;
+      int16_t dynamic_precedence;
+      uint8_t child_count;
+      uint8_t production_id;
+    } reduce;
+  } params;
+  TSParseActionType type : 4;
 } TSParseAction;
 
 typedef struct {
@@ -83,7 +82,7 @@ typedef union {
   TSParseAction action;
   struct {
     uint8_t count;
-    bool reusable;
+    bool reusable : 1;
   } entry;
 } TSParseActionEntry;
 
@@ -93,24 +92,13 @@ struct TSLanguage {
   uint32_t alias_count;
   uint32_t token_count;
   uint32_t external_token_count;
-  uint32_t state_count;
-  uint32_t large_state_count;
-  uint32_t production_id_count;
-  uint32_t field_count;
-  uint16_t max_alias_sequence_length;
-  const uint16_t *parse_table;
-  const uint16_t *small_parse_table;
-  const uint32_t *small_parse_table_map;
-  const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
-  const TSFieldMapEntry *field_map_entries;
+  const char **symbol_names;
   const TSSymbolMetadata *symbol_metadata;
-  const TSSymbol *public_symbol_map;
-  const uint16_t *alias_map;
-  const TSSymbol *alias_sequences;
+  const uint16_t *parse_table;
+  const TSParseActionEntry *parse_actions;
   const TSLexMode *lex_modes;
+  const TSSymbol *alias_sequences;
+  uint16_t max_alias_sequence_length;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -123,6 +111,14 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  uint32_t field_count;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const char **field_names;
+  uint32_t large_state_count;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSSymbol *public_symbol_map;
 };
 
 /*
@@ -171,50 +167,66 @@ struct TSLanguage {
 
 #define ACTIONS(id) id
 
-#define SHIFT(state_value)            \
-  {{                                  \
-    .shift = {                        \
-      .type = TSParseActionTypeShift, \
-      .state = state_value            \
-    }                                 \
-  }}
+#define SHIFT(state_value)                \
+  {                                       \
+    {                                     \
+      .params = {                         \
+        .shift = {                        \
+          .state = state_value            \
+        }                                 \
+      },                                  \
+      .type = TSParseActionTypeShift      \
+    }                                     \
+  }
 
 #define SHIFT_REPEAT(state_value)     \
-  {{                                  \
-    .shift = {                        \
-      .type = TSParseActionTypeShift, \
-      .state = state_value,           \
-      .repetition = true              \
+  {                                   \
+    {                                 \
+      .params = {                     \
+        .shift = {                    \
+          .state = state_value,       \
+          .repetition = true          \
+        }                             \
+      },                              \
+      .type = TSParseActionTypeShift  \
     }                                 \
-  }}
+  }
+
+#define RECOVER()                        \
+  {                                      \
+    { .type = TSParseActionTypeRecover } \
+  }
 
 #define SHIFT_EXTRA()                 \
-  {{                                  \
-    .shift = {                        \
-      .type = TSParseActionTypeShift, \
-      .extra = true                   \
+  {                                   \
+    {                                 \
+      .params = {                     \
+        .shift = {                    \
+          .extra = true               \
+        }                             \
+      },                              \
+      .type = TSParseActionTypeShift  \
     }                                 \
-  }}
+  }
 
 #define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
-  }}
+  {                                              \
+    {                                            \
+      .params = {                                \
+        .reduce = {                              \
+          .symbol = symbol_val,                  \
+          .child_count = child_count_val,        \
+          __VA_ARGS__                            \
+        },                                       \
+      },                                         \
+      .type = TSParseActionTypeReduce            \
+    }                                            \
+  }
 
-#define RECOVER()                    \
-  {{                                 \
-    .type = TSParseActionTypeRecover \
-  }}
-
-#define ACCEPT_INPUT()              \
-  {{                                \
-    .type = TSParseActionTypeAccept \
-  }}
+#define ACCEPT_INPUT()                  \
+  {                                     \
+    { .type = TSParseActionTypeAccept } \
+  }
 
 #ifdef __cplusplus
 }

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -1,0 +1,131 @@
+==================
+Dot after newline
+==================
+
+bar.foo()
+   .show()
+
+---
+
+(source_file
+   (call_expression
+     (navigation_expression
+        (call_expression
+          (navigation_expression (simple_identifier)
+             (navigation_suffix (simple_identifier)))
+          (call_suffix (value_arguments)))
+        (navigation_suffix (simple_identifier)))
+      (call_suffix (value_arguments)))) 
+
+==================
+Eq after newline
+==================
+
+fun foo()
+    = 1
+
+---
+(source_file
+   (function_declaration (simple_identifier)
+      (function_body (integer_literal))))
+
+==================
+Binary operator after newline
+==================
+
+
+fun foo()  {
+  val bar = x
+         && y
+}
+
+---
+(source_file
+  (function_declaration (simple_identifier)
+     (function_body
+        (statements
+           (property_declaration
+              (variable_declaration (simple_identifier))
+              (conjunction_expression (simple_identifier) (simple_identifier)))))))
+
+
+==================
+Open brace after newline
+==================
+
+fun foo():String
+    { return "bar"}
+
+---
+(source_file
+   (function_declaration (simple_identifier)
+      (user_type (type_identifier))
+      (function_body (statements (jump_expression (line_string_literal))))))
+
+==================
+Colon after newline
+==================
+
+class Foo
+    : Bar {
+}
+
+---
+
+(source_file
+  (class_declaration (type_identifier)
+     (delegation_specifier (user_type (type_identifier)))
+     (class_body)))
+
+==================
+Question mark after newline
+==================
+
+
+fun foo() {
+   val foo = a?.bar(true)
+             ?: x.foo()
+             ?: break
+}
+
+---
+
+(source_file
+  (function_declaration (simple_identifier)
+    (function_body
+      (statements
+        (property_declaration
+          (variable_declaration (simple_identifier))
+            (elvis_expression
+              (elvis_expression
+                (call_expression
+                   (navigation_expression (simple_identifier)
+                     (navigation_suffix (simple_identifier)))
+                   (call_suffix
+                     (value_arguments (value_argument (boolean_literal)))))
+                (call_expression
+                   (navigation_expression (simple_identifier)
+                      (navigation_suffix (simple_identifier)))
+                    (call_suffix (value_arguments))))
+               (jump_expression)))))))
+
+==================
+Newline in function call
+==================
+
+// The Kotlin grammar does not allow newlines/semicolons in function calls,
+// but tree-sitter uses context-aware lexing to overcome this.
+
+foo(1,
+    2)
+
+---
+
+(source_file
+  (comment)
+  (comment)
+  (call_expression (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument (integer_literal))
+        (value_argument (integer_literal))))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -19,31 +19,35 @@ something as A
 Nested types
 ==================
 
+// TODO the introduction of scanner.c changed the AST for nested types
 something as Some.NestedType
 
 ---
-
 (source_file
-  (as_expression
-    (simple_identifier)
-    (user_type (type_identifier) (type_identifier))))
+   (comment)
+   (navigation_expression
+      (as_expression (simple_identifier)
+          (user_type (type_identifier)))
+      (navigation_suffix (simple_identifier))))
 
 ==================
 Deeply nested types
 ==================
 
+// TODO the introduction of scanner.c changed the AST for nested types
 somethingElse as A.Deeply.Nested.Type
 
 ---
-
 (source_file
-  (as_expression
-    (simple_identifier)
-    (user_type
-      (type_identifier)
-      (type_identifier)
-      (type_identifier)
-      (type_identifier))))
+   (comment)
+   (navigation_expression
+      (navigation_expression
+         (navigation_expression
+	    (as_expression (simple_identifier) (user_type (type_identifier)))
+	    (navigation_suffix (simple_identifier)))
+	 (navigation_suffix (simple_identifier)))
+      (navigation_suffix (simple_identifier))))
+
 
 ==================
 Generic wildcard types


### PR DESCRIPTION
This imitates the Automatic Semicolon Insertions (ASI) done in
Javascript for Kotlin, to better deal with newlines that can cut
certain definitions and expressions in two.

This closes https://github.com/fwcd/tree-sitter-kotlin/issues/32

test plan:
see new newlines.txt corpus test