### PR TITLE
Parse getter/setter even when after a newline

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -77,6 +77,8 @@ module.exports = grammar({
 
     // "expect" as a plaform modifier conflicts with expect as an identifier
     [$.platform_modifier, $.simple_identifier],
+    // "data", "inner" as class modifier or id
+    [$.class_modifier, $.simple_identifier],
 
     // "<x>.<y> = z assignment conflicts with <x>.<y>() function call"
     [$._postfix_unary_expression, $._expression],
@@ -169,6 +171,15 @@ module.exports = grammar({
       $.object_declaration,
       $.function_declaration,
       $.property_declaration,
+      // TODO: it would be better to have getter/setter only in
+      // property_declaration but it's difficult to get ASI
+      // (Automatic Semicolon Insertion) working in the lexer for
+      // getter/setter. Indeed, they can also have modifiers in
+      // front, which means it's not enough to lookahead for 'get' or 'set' in
+      // the lexer, you also need to handle modifier keywords. It is thus
+      // simpler to accept them here.
+      $.getter,
+      $.setter,
       $.type_alias
     ),
 
@@ -343,7 +354,7 @@ module.exports = grammar({
     property_delegate: $ => seq("by", $._expression),
 
     getter: $ => prec.right(seq(
-      // optional(seq($._semi, $.modifiers)), // TODO
+      optional($.modifiers),
       "get",
       optional(seq(
         "(", ")",
@@ -353,7 +364,7 @@ module.exports = grammar({
     )),
 
     setter: $ => prec.right(seq(
-      // optional(seq($._semi, $.modifiers)), // TODO
+      optional($.modifiers),
       "set",
       optional(seq(
         "(",
@@ -1049,7 +1060,10 @@ module.exports = grammar({
 
     simple_identifier: $ => choice(
       $._lexical_identifier,
-      "expect"
+      "expect",
+      "data",
+      "inner",
+      "actual",
       // TODO: More soft keywords
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -282,6 +282,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "getter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "setter"
+        },
+        {
+          "type": "SYMBOL",
           "name": "type_alias"
         }
       ]
@@ -1560,6 +1568,18 @@
         "type": "SEQ",
         "members": [
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "modifiers"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
             "type": "STRING",
             "value": "get"
           },
@@ -1618,6 +1638,18 @@
       "content": {
         "type": "SEQ",
         "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "modifiers"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
           {
             "type": "STRING",
             "value": "set"
@@ -5250,6 +5282,18 @@
         {
           "type": "STRING",
           "value": "expect"
+        },
+        {
+          "type": "STRING",
+          "value": "data"
+        },
+        {
+          "type": "STRING",
+          "value": "inner"
+        },
+        {
+          "type": "STRING",
+          "value": "actual"
         }
       ]
     },
@@ -6014,6 +6058,10 @@
     ],
     [
       "platform_modifier",
+      "simple_identifier"
+    ],
+    [
+      "class_modifier",
       "simple_identifier"
     ],
     [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1098,6 +1098,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "object_declaration",
           "named": true
         },
@@ -1107,6 +1111,10 @@
         },
         {
           "type": "secondary_constructor",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -2026,6 +2034,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -2107,6 +2119,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -2836,6 +2852,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "object_declaration",
           "named": true
         },
@@ -2845,6 +2865,10 @@
         },
         {
           "type": "secondary_constructor",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -3939,6 +3963,10 @@
         },
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "modifiers",
           "named": true
         },
         {
@@ -7297,6 +7325,10 @@
           "named": true
         },
         {
+          "type": "modifiers",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -7426,6 +7458,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -7515,6 +7551,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -7824,6 +7864,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -7905,6 +7949,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -110,6 +110,28 @@ fun foo() {
                (jump_expression)))))))
 
 ==================
+get after newline
+==================
+class Foo {
+     val maxMemory: Long
+     get() = bar() / 1024
+}
+
+---
+(source_file
+  (class_declaration (type_identifier)
+    (class_body
+      (property_declaration
+        (variable_declaration (simple_identifier)
+	  (user_type (type_identifier))))
+      (getter
+         (function_body
+	   (multiplicative_expression
+	     (call_expression (simple_identifier)
+	        (call_suffix (value_arguments)))
+	     (integer_literal)))))))
+
+==================
 Newline in function call
 ==================
 

--- a/test/corpus/soft_keywords.txt
+++ b/test/corpus/soft_keywords.txt
@@ -1,0 +1,23 @@
+==================
+Actual as an identifier
+==================
+
+
+fun foo() {
+  val actual = IntArray(n)
+  actual[0]++
+}
+
+---
+(source_file
+  (function_declaration (simple_identifier)
+    (function_body
+      (statements
+         (property_declaration
+	   (variable_declaration (simple_identifier))
+	   (call_expression (simple_identifier)
+	     (call_suffix
+	       (value_arguments (value_argument (simple_identifier))))))
+	 (postfix_expression
+	    (indexing_expression (simple_identifier)
+  	      (indexing_suffix (integer_literal))))))))


### PR DESCRIPTION
This improves our parsing stats to 98.6% on our Kotlin corpus

test plan:
test file included
$ tree-sitter test