### PR TITLE
taking out comments in grammar 

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -666,8 +666,8 @@ module.exports = grammar({
     )),
 
     annotated_lambda: $ => seq(
-      // repeat($.annotation),
-      // optional($.label),
+      repeat($.annotation),
+      optional($.label),
       $.lambda_literal
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -77,6 +77,8 @@ module.exports = grammar({
 
     // "expect" as a plaform modifier conflicts with expect as an identifier
     [$.platform_modifier, $.simple_identifier],
+    // "data", "inner" as class modifier or id
+    [$.class_modifier, $.simple_identifier],
 
     // "<x>.<y> = z assignment conflicts with <x>.<y>() function call"
     [$._postfix_unary_expression, $._expression],
@@ -169,6 +171,15 @@ module.exports = grammar({
       $.object_declaration,
       $.function_declaration,
       $.property_declaration,
+      // TODO: it would be better to have getter/setter only in
+      // property_declaration but it's difficult to get ASI
+      // (Automatic Semicolon Insertion) working in the lexer for
+      // getter/setter. Indeed, they can also have modifiers in
+      // front, which means it's not enough to lookahead for 'get' or 'set' in
+      // the lexer, you also need to handle modifier keywords. It is thus
+      // simpler to accept them here.
+      $.getter,
+      $.setter,
       $.type_alias
     ),
 
@@ -343,7 +354,7 @@ module.exports = grammar({
     property_delegate: $ => seq("by", $._expression),
 
     getter: $ => prec.right(seq(
-      // optional(seq($._semi, $.modifiers)), // TODO
+      optional($.modifiers),
       "get",
       optional(seq(
         "(", ")",
@@ -353,7 +364,7 @@ module.exports = grammar({
     )),
 
     setter: $ => prec.right(seq(
-      // optional(seq($._semi, $.modifiers)), // TODO
+      optional($.modifiers),
       "set",
       optional(seq(
         "(",
@@ -1049,7 +1060,10 @@ module.exports = grammar({
 
     simple_identifier: $ => choice(
       $._lexical_identifier,
-      "expect"
+      "expect",
+      "data",
+      "inner",
+      "actual",
       // TODO: More soft keywords
     ),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,20 +5,21 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tree-sitter-kotlin",
       "version": "0.2.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.12.1"
+        "nan": "^2.15.0"
       },
       "devDependencies": {
         "tree-sitter-cli": "^0.20.0"
       }
     },
     "node_modules/nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "node_modules/tree-sitter-cli": {
       "version": "0.20.0",
@@ -33,9 +34,9 @@
   },
   "dependencies": {
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "tree-sitter-cli": {
       "version": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/fwcd/tree-sitter-kotlin#readme",
   "dependencies": {
-    "nan": "^2.12.1"
+    "nan": "^2.15.0"
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.20.0"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -282,6 +282,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "getter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "setter"
+        },
+        {
+          "type": "SYMBOL",
           "name": "type_alias"
         }
       ]
@@ -1560,6 +1568,18 @@
         "type": "SEQ",
         "members": [
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "modifiers"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
             "type": "STRING",
             "value": "get"
           },
@@ -1618,6 +1638,18 @@
       "content": {
         "type": "SEQ",
         "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "modifiers"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
           {
             "type": "STRING",
             "value": "set"
@@ -5250,6 +5282,18 @@
         {
           "type": "STRING",
           "value": "expect"
+        },
+        {
+          "type": "STRING",
+          "value": "data"
+        },
+        {
+          "type": "STRING",
+          "value": "inner"
+        },
+        {
+          "type": "STRING",
+          "value": "actual"
         }
       ]
     },
@@ -6014,6 +6058,10 @@
     ],
     [
       "platform_modifier",
+      "simple_identifier"
+    ],
+    [
+      "class_modifier",
       "simple_identifier"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6136,6 +6136,7 @@
       "function_type"
     ]
   ],
+  "precedences": [],
   "externals": [
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1098,6 +1098,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "object_declaration",
           "named": true
         },
@@ -1107,6 +1111,10 @@
         },
         {
           "type": "secondary_constructor",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -2026,6 +2034,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -2107,6 +2119,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -2836,6 +2852,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "object_declaration",
           "named": true
         },
@@ -2845,6 +2865,10 @@
         },
         {
           "type": "secondary_constructor",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -3939,6 +3963,10 @@
         },
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "modifiers",
           "named": true
         },
         {
@@ -7297,6 +7325,10 @@
           "named": true
         },
         {
+          "type": "modifiers",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -7426,6 +7458,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -7515,6 +7551,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {
@@ -7824,6 +7864,10 @@
           "named": true
         },
         {
+          "type": "getter",
+          "named": true
+        },
+        {
           "type": "hex_literal",
           "named": true
         },
@@ -7905,6 +7949,10 @@
         },
         {
           "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "setter",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9399,6 +9399,10 @@
     "named": false
   },
   {
+    "type": "comment",
+    "named": true
+  },
+  {
     "type": "companion",
     "named": false
   },

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -51,6 +51,14 @@ static bool scan_whitespace_and_comments(TSLexer *lexer) {
   }
 }
 
+bool scan_for_word(TSLexer *lexer, char* word, unsigned len) {
+    advance(lexer);
+    for (unsigned i = 0; i < len; i++) {
+      if (lexer->lookahead != word[i]) return true;
+      advance(lexer);
+    }
+    return false;
+}
 
 bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
                                                   const bool *valid_symbols) {
@@ -83,6 +91,14 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
     case '&': // ex: binary operator between 2 exprs
 
       return false;
+    
+    //case 'e': // ex: else on next line after 'if' control body
+    //  return scan_for_word(lexer, "lse", 3);
+    case 's': // ex: getter function defined on line after variable declaration
+    case 'g': // ex: setter function defined on line after variable declaration
+      return scan_for_word(lexer, "et()", 4);
+    case 'e':
+      return scan_for_word(lexer, "lse", 3);
   }
 
   return true;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -79,6 +79,11 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
 
   switch (lexer->lookahead) {
     // specific to Kotlin
+    case 's': // ex: getter function defined on line after variable declaration
+    case 'g': // ex: setter function defined on line after variable declaration
+      return scan_for_word(lexer, "et()", 4);
+    case 'e': // ex: else on next line after 'if' control body
+      return scan_for_word(lexer, "lse", 3);
     case '{': // ex: function body defined on next line after decl
 
     // cases also in tree-sitter-javascript/src/scanner.c
@@ -91,14 +96,6 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
     case '&': // ex: binary operator between 2 exprs
 
       return false;
-    
-    //case 'e': // ex: else on next line after 'if' control body
-    //  return scan_for_word(lexer, "lse", 3);
-    case 's': // ex: getter function defined on line after variable declaration
-    case 'g': // ex: setter function defined on line after variable declaration
-      return scan_for_word(lexer, "et()", 4);
-    case 'e':
-      return scan_for_word(lexer, "lse", 3);
   }
 
   return true;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -51,14 +51,6 @@ static bool scan_whitespace_and_comments(TSLexer *lexer) {
   }
 }
 
-bool scan_for_word(TSLexer *lexer, char* word, unsigned len) {
-    advance(lexer);
-    for (unsigned i = 0; i < len; i++) {
-      if (lexer->lookahead != word[i]) return true;
-      advance(lexer);
-    }
-    return false;
-}
 
 bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
                                                   const bool *valid_symbols) {
@@ -79,11 +71,6 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
 
   switch (lexer->lookahead) {
     // specific to Kotlin
-    case 's': // ex: getter function defined on line after variable declaration
-    case 'g': // ex: setter function defined on line after variable declaration
-      return scan_for_word(lexer, "et()", 4);
-    case 'e': // ex: else on next line after 'if' control body
-      return scan_for_word(lexer, "lse", 3);
     case '{': // ex: function body defined on next line after decl
 
     // cases also in tree-sitter-javascript/src/scanner.c

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -51,6 +51,14 @@ static bool scan_whitespace_and_comments(TSLexer *lexer) {
   }
 }
 
+bool scan_for_word(TSLexer *lexer, char* word, unsigned len) {
+    advance(lexer);
+    for (unsigned i = 0; i < len; i++) {
+      if (lexer->lookahead != word[i]) return true;
+      advance(lexer);
+    }
+    return false;
+}
 
 bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
                                                   const bool *valid_symbols) {
@@ -71,6 +79,8 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
 
   switch (lexer->lookahead) {
     // specific to Kotlin
+    case 'e': // ex: else on next line after 'if' control body
+      return scan_for_word(lexer, "lse", 3);
     case '{': // ex: function body defined on next line after decl
 
     // cases also in tree-sitter-javascript/src/scanner.c

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,6 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
+typedef uint16_t TSStateId;
+
 #ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
@@ -30,11 +32,10 @@ typedef struct {
   uint16_t length;
 } TSFieldMapSlice;
 
-typedef uint16_t TSStateId;
-
 typedef struct {
-  bool visible : 1;
-  bool named : 1;
+  bool visible;
+  bool named;
+  bool supertype;
 } TSSymbolMetadata;
 
 typedef struct TSLexer TSLexer;
@@ -56,21 +57,21 @@ typedef enum {
   TSParseActionTypeRecover,
 } TSParseActionType;
 
-typedef struct {
-  union {
-    struct {
-      TSStateId state;
-      bool extra : 1;
-      bool repetition : 1;
-    } shift;
-    struct {
-      TSSymbol symbol;
-      int16_t dynamic_precedence;
-      uint8_t child_count;
-      uint8_t production_id;
-    } reduce;
-  } params;
-  TSParseActionType type : 4;
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
 } TSParseAction;
 
 typedef struct {
@@ -82,7 +83,7 @@ typedef union {
   TSParseAction action;
   struct {
     uint8_t count;
-    bool reusable : 1;
+    bool reusable;
   } entry;
 } TSParseActionEntry;
 
@@ -92,13 +93,24 @@ struct TSLanguage {
   uint32_t alias_count;
   uint32_t token_count;
   uint32_t external_token_count;
-  const char **symbol_names;
-  const TSSymbolMetadata *symbol_metadata;
-  const uint16_t *parse_table;
-  const TSParseActionEntry *parse_actions;
-  const TSLexMode *lex_modes;
-  const TSSymbol *alias_sequences;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
   uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -111,14 +123,6 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
-  uint32_t field_count;
-  const TSFieldMapSlice *field_map_slices;
-  const TSFieldMapEntry *field_map_entries;
-  const char **field_names;
-  uint32_t large_state_count;
-  const uint16_t *small_parse_table;
-  const uint32_t *small_parse_table_map;
-  const TSSymbol *public_symbol_map;
 };
 
 /*
@@ -167,66 +171,50 @@ struct TSLanguage {
 
 #define ACTIONS(id) id
 
-#define SHIFT(state_value)                \
-  {                                       \
-    {                                     \
-      .params = {                         \
-        .shift = {                        \
-          .state = state_value            \
-        }                                 \
-      },                                  \
-      .type = TSParseActionTypeShift      \
-    }                                     \
-  }
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value            \
+    }                                 \
+  }}
 
 #define SHIFT_REPEAT(state_value)     \
-  {                                   \
-    {                                 \
-      .params = {                     \
-        .shift = {                    \
-          .state = state_value,       \
-          .repetition = true          \
-        }                             \
-      },                              \
-      .type = TSParseActionTypeShift  \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value,           \
+      .repetition = true              \
     }                                 \
-  }
-
-#define RECOVER()                        \
-  {                                      \
-    { .type = TSParseActionTypeRecover } \
-  }
+  }}
 
 #define SHIFT_EXTRA()                 \
-  {                                   \
-    {                                 \
-      .params = {                     \
-        .shift = {                    \
-          .extra = true               \
-        }                             \
-      },                              \
-      .type = TSParseActionTypeShift  \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
     }                                 \
-  }
+  }}
 
 #define REDUCE(symbol_val, child_count_val, ...) \
-  {                                              \
-    {                                            \
-      .params = {                                \
-        .reduce = {                              \
-          .symbol = symbol_val,                  \
-          .child_count = child_count_val,        \
-          __VA_ARGS__                            \
-        },                                       \
-      },                                         \
-      .type = TSParseActionTypeReduce            \
-    }                                            \
-  }
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
+  }}
 
-#define ACCEPT_INPUT()                  \
-  {                                     \
-    { .type = TSParseActionTypeAccept } \
-  }
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
 
 #ifdef __cplusplus
 }

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -15,7 +15,7 @@ bar.foo()
              (navigation_suffix (simple_identifier)))
           (call_suffix (value_arguments)))
         (navigation_suffix (simple_identifier)))
-      (call_suffix (value_arguments))))
+      (call_suffix (value_arguments)))) 
 
 ==================
 Eq after newline
@@ -151,45 +151,3 @@ foo(1,
       (value_arguments
         (value_argument (integer_literal))
         (value_argument (integer_literal))))))
-
-
-==================
-Else after newline
-==================
-
-if (!foo) 3
-else boo()
-
----
-
-(source_file
-  (if_expression
-    (prefix_expression
-      (simple_identifier))
-    (control_structure_body
-      (integer_literal))
-    (control_structure_body
-      (call_expression
-        (simple_identifier)
-        (call_suffix
-          (value_arguments))))))
-
-==================
-Getter after newline
-==================
-
- val maxMemory: Long
-     get() = 1024
-
----
-
-(source_file
-  (property_declaration
-    (variable_declaration
-      (simple_identifier)
-      (user_type
-        (type_identifier)))
-    (getter
-      (function_body
-        (integer_literal)))))
-

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -110,6 +110,28 @@ fun foo() {
                (jump_expression)))))))
 
 ==================
+get after newline
+==================
+class Foo {
+     val maxMemory: Long
+     get() = bar() / 1024
+}
+
+---
+(source_file
+  (class_declaration (type_identifier)
+    (class_body
+      (property_declaration
+        (variable_declaration (simple_identifier)
+	  (user_type (type_identifier))))
+      (getter
+         (function_body
+	   (multiplicative_expression
+	     (call_expression (simple_identifier)
+	        (call_suffix (value_arguments)))
+	     (integer_literal)))))))
+
+==================
 Newline in function call
 ==================
 

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -15,7 +15,7 @@ bar.foo()
              (navigation_suffix (simple_identifier)))
           (call_suffix (value_arguments)))
         (navigation_suffix (simple_identifier)))
-      (call_suffix (value_arguments)))) 
+      (call_suffix (value_arguments))))
 
 ==================
 Eq after newline
@@ -151,3 +151,25 @@ foo(1,
       (value_arguments
         (value_argument (integer_literal))
         (value_argument (integer_literal))))))
+
+
+==================
+Else after newline
+==================
+
+if (!foo) 3
+else boo()
+
+---
+
+(source_file
+  (if_expression
+    (prefix_expression
+      (simple_identifier))
+    (control_structure_body
+      (integer_literal))
+    (control_structure_body
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments))))))

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -15,7 +15,7 @@ bar.foo()
              (navigation_suffix (simple_identifier)))
           (call_suffix (value_arguments)))
         (navigation_suffix (simple_identifier)))
-      (call_suffix (value_arguments)))) 
+      (call_suffix (value_arguments))))
 
 ==================
 Eq after newline
@@ -151,3 +151,45 @@ foo(1,
       (value_arguments
         (value_argument (integer_literal))
         (value_argument (integer_literal))))))
+
+
+==================
+Else after newline
+==================
+
+if (!foo) 3
+else boo()
+
+---
+
+(source_file
+  (if_expression
+    (prefix_expression
+      (simple_identifier))
+    (control_structure_body
+      (integer_literal))
+    (control_structure_body
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments))))))
+
+==================
+Getter after newline
+==================
+
+ val maxMemory: Long
+     get() = 1024
+
+---
+
+(source_file
+  (property_declaration
+    (variable_declaration
+      (simple_identifier)
+      (user_type
+        (type_identifier)))
+    (getter
+      (function_body
+        (integer_literal)))))
+

--- a/test/corpus/soft_keywords.txt
+++ b/test/corpus/soft_keywords.txt
@@ -1,0 +1,23 @@
+==================
+Actual as an identifier
+==================
+
+
+fun foo() {
+  val actual = IntArray(n)
+  actual[0]++
+}
+
+---
+(source_file
+  (function_declaration (simple_identifier)
+    (function_body
+      (statements
+         (property_declaration
+	   (variable_declaration (simple_identifier))
+	   (call_expression (simple_identifier)
+	     (call_suffix
+	       (value_arguments (value_argument (simple_identifier))))))
+	 (postfix_expression
+	    (indexing_expression (simple_identifier)
+  	      (indexing_suffix (integer_literal))))))))


### PR DESCRIPTION
This PR:

* un-comments portions of `annotated_lambda` that increases parsing to 97%. 
* adds the case where else comes after a newline following the `if` control body into scanner.cc

To test, run `npx tree-sitter test`

cc: @aryx 