### PR TITLE
small grammer edits to get us over 99% parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -105,7 +105,11 @@ module.exports = grammar({
     [$.user_type, $.function_type],
 
     // ambiguity between annotated_lambda with modifiers and modifiers from var declarations
-    [$.annotated_lambda, $.modifiers]
+    [$.annotated_lambda, $.modifiers],
+
+    // ambiguity between simple identifier 'set/get' with actual setter/getter functions.
+    [$.setter, $.simple_identifier],
+    [$.getter, $.simple_identifier],
   ],
 
   externals: $ => [
@@ -220,7 +224,12 @@ module.exports = grammar({
 
     class_body: $ => seq("{", optional($._class_member_declarations), "}"),
 
-    _class_parameters: $ => seq("(", optional(sep1($.class_parameter, ",")), ")"),
+    _class_parameters: $ => seq(
+      "(",
+      optional(sep1($.class_parameter, ",")),
+      optional(","),
+      ")"
+    ),
 
     class_parameter: $ => seq(
       optional($.modifiers),
@@ -298,7 +307,12 @@ module.exports = grammar({
       optional($.class_body)
     ),
 
-    _function_value_parameters: $ => seq("(", optional(sep1($._function_value_parameter, ",")), ")"),
+    _function_value_parameters: $ => seq(
+      "(",
+      optional(sep1($._function_value_parameter, ",")),
+      optional(","),
+      ")"
+    ),
 
     _function_value_parameter: $ => seq(
       optional($.parameter_modifiers),
@@ -1067,6 +1081,8 @@ module.exports = grammar({
       "data",
       "inner",
       "actual",
+      "set",
+      "get"
       // TODO: More soft keywords
     ),
 

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -301,3 +301,29 @@ Type alias declaration
       (type_identifier)
       (type_identifier)
       (type_identifier))))
+
+==================
+Data class with hanging comma
+==================
+
+data class JwtConfiguration(
+   val audience: String,
+   val realm: String,
+)
+
+---
+
+(source_file
+  (class_declaration
+    (modifiers
+      (class_modifier))
+    (type_identifier)
+    (primary_constructor
+      (class_parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier)))
+      (class_parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier))))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -125,7 +125,7 @@ fun foo(p0: Int): Long {
               (value_arguments))))))))
 
 =====================
-Override functions
+override functions
 ======================
 
 override fun boo() = foo()
@@ -142,3 +142,32 @@ override fun boo() = foo()
         (simple_identifier)
         (call_suffix
           (value_arguments))))))
+
+=====================
+Set function call
+======================
+
+fun test() {
+    isAccessible = true
+    set(it, COROUTINE_SUSPENDED)
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_body
+      (statements
+        (assignment
+          (directly_assignable_expression
+            (simple_identifier))
+          (boolean_literal))
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier))
+              (value_argument
+                (simple_identifier)))))))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -125,7 +125,7 @@ fun foo(p0: Int): Long {
               (value_arguments))))))))
 
 =====================
-override functions
+Override functions
 ======================
 
 override fun boo() = foo()


### PR DESCRIPTION
This PR:
* adds `set` and `get` as possible simple_identifiers
* adds optional commas after parameters

I'm getting around 99.05% parsing after these changes.

_To test:_
`npx tree-sitter test`

cc: @aryx @fwcd 