### PR TITLE
Minor grammar fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -110,6 +110,9 @@ module.exports = grammar({
     // ambiguity between simple identifier 'set/get' with actual setter/getter functions.
     [$.setter, $.simple_identifier],
     [$.getter, $.simple_identifier],
+
+    // ambiguity between parameter modifiers in anonymous functions
+    [$.parameter_modifiers, $._type_modifier],
   ],
 
   externals: $ => [
@@ -785,7 +788,8 @@ module.exports = grammar({
     anonymous_function: $ => seq(
       "fun",
       optional(seq(sep1($._simple_user_type, "."), ".")), // TODO
-      "(", ")",
+      $._function_value_parameters,
+      optional(seq(":", $._type)),
       optional($.function_body)
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -908,7 +908,7 @@ module.exports = grammar({
 
     _in_operator: $ => choice("in", "!in"),
 
-    _is_operator: $ => choice("is", $._not_is),
+    _is_operator: $ => choice("is", "!is"),
 
     _additive_operator: $ => choice("+", "-"),
 
@@ -920,13 +920,12 @@ module.exports = grammar({
 
     _postfix_unary_operator: $ => choice("++", "--", "!!"),
 
-    _member_access_operator: $ => choice(".", $._safe_nav, "::"),
-
-    _safe_nav: $ => "?.",      // TODO: '?' and '.' should actually be separate tokens
-                               //       but produce an LR(1) conflict that way, however.
-                               //       ('as' expression with '?' produces conflict). Also
-                               //       does it seem to be very uncommon to write the safe
-                               //       navigation operator 'split up' in Kotlin.
+    // TODO: '?' and '.' should actually be separate tokens
+    //       but produce an LR(1) conflict that way, however.
+    //       ('as' expression with '?' produces conflict). Also
+    //       does it seem to be very uncommon to write the safe
+    //       navigation operator 'split up' in Kotlin.
+    _member_access_operator: $ => choice(".", "?.", "::"),
 
     _indexing_suffix: $ => seq(
       '[',
@@ -1121,10 +1120,6 @@ module.exports = grammar({
     _this_at: $ => seq("this@", $._lexical_identifier),
 
     _super_at: $ => seq("super@", $._lexical_identifier),
-
-    _not_is: $ => "!is",
-
-    _not_in: $ => "!in",
 
     // ==========
     // Literals

--- a/grammar.js
+++ b/grammar.js
@@ -750,7 +750,7 @@ module.exports = grammar({
 
     _line_string_content: $ => choice(
       $._line_str_text,
-      $._line_str_escaped_char
+      $.character_escape_seq
     ),
 
     line_string_expression: $ => seq("${", $._expression, "}"),
@@ -1157,10 +1157,14 @@ module.exports = grammar({
 
     character_literal: $ => seq(
       "'",
-      choice($._escape_seq, /[^\n\r'\\]/),
+      choice($.character_escape_seq, /[^\n\r'\\]/),
       "'"
     ),
 
+    character_escape_seq: $ => choice(
+      $._uni_character_literal,
+      $._escaped_identifier
+    ),
 
     // ==========
     // Identifiers
@@ -1182,21 +1186,11 @@ module.exports = grammar({
 
     _escaped_identifier: $ => /\\[tbrn'"\\$]/,
 
-    _escape_seq: $ => choice(
-      $._uni_character_literal,
-      $._escaped_identifier
-    ),
-
     // ==========
     // Strings
     // ==========
 
     _line_str_text: $ => /[^\\"$]+/,
-
-    _line_str_escaped_char: $ => choice(
-      $._escaped_identifier,
-      $._uni_character_literal
-    ),
 
     _multi_line_str_text: $ => /[^"$]+/
   }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -618,6 +618,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": ")"
         }
@@ -1114,6 +1126,18 @@
                   }
                 }
               ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
             },
             {
               "type": "BLANK"
@@ -3376,6 +3400,25 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "annotation"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "label"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "lambda_literal"
         }
@@ -3751,7 +3794,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_line_str_escaped_char"
+          "name": "character_escape_seq"
         }
       ]
     },
@@ -4014,12 +4057,29 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "("
+          "type": "SYMBOL",
+          "name": "_function_value_parameters"
         },
         {
-          "type": "STRING",
-          "value": ")"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_type"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -4664,8 +4724,8 @@
           "value": "is"
         },
         {
-          "type": "SYMBOL",
-          "name": "_not_is"
+          "type": "STRING",
+          "value": "!is"
         }
       ]
     },
@@ -4762,18 +4822,14 @@
           "value": "."
         },
         {
-          "type": "SYMBOL",
-          "name": "_safe_nav"
+          "type": "STRING",
+          "value": "?."
         },
         {
           "type": "STRING",
           "value": "::"
         }
       ]
-    },
-    "_safe_nav": {
-      "type": "STRING",
-      "value": "?."
     },
     "_indexing_suffix": {
       "type": "SEQ",
@@ -5294,6 +5350,14 @@
         {
           "type": "STRING",
           "value": "actual"
+        },
+        {
+          "type": "STRING",
+          "value": "set"
+        },
+        {
+          "type": "STRING",
+          "value": "get"
         }
       ]
     },
@@ -5428,14 +5492,6 @@
           "name": "_lexical_identifier"
         }
       ]
-    },
-    "_not_is": {
-      "type": "STRING",
-      "value": "!is"
-    },
-    "_not_in": {
-      "type": "STRING",
-      "value": "!in"
     },
     "real_literal": {
       "type": "TOKEN",
@@ -5947,7 +6003,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_escape_seq"
+              "name": "character_escape_seq"
             },
             {
               "type": "PATTERN",
@@ -5958,6 +6014,19 @@
         {
           "type": "STRING",
           "value": "'"
+        }
+      ]
+    },
+    "character_escape_seq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_uni_character_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_escaped_identifier"
         }
       ]
     },
@@ -5999,35 +6068,9 @@
       "type": "PATTERN",
       "value": "\\\\[tbrn'\"\\\\$]"
     },
-    "_escape_seq": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_uni_character_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_escaped_identifier"
-        }
-      ]
-    },
     "_line_str_text": {
       "type": "PATTERN",
       "value": "[^\\\\\"$]+"
-    },
-    "_line_str_escaped_char": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_escaped_identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_uni_character_literal"
-        }
-      ]
     },
     "_multi_line_str_text": {
       "type": "PATTERN",
@@ -6134,6 +6177,22 @@
     [
       "user_type",
       "function_type"
+    ],
+    [
+      "annotated_lambda",
+      "modifiers"
+    ],
+    [
+      "setter",
+      "simple_identifier"
+    ],
+    [
+      "getter",
+      "simple_identifier"
+    ],
+    [
+      "parameter_modifiers",
+      "_type_modifier"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -175,9 +175,17 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
         {
           "type": "lambda_literal",
           "named": true
@@ -217,7 +225,179 @@
       "required": false,
       "types": [
         {
+          "type": "additive_expression",
+          "named": true
+        },
+        {
+          "type": "anonymous_function",
+          "named": true
+        },
+        {
+          "type": "as_expression",
+          "named": true
+        },
+        {
+          "type": "bin_literal",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "callable_reference",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "check_expression",
+          "named": true
+        },
+        {
+          "type": "collection_literal",
+          "named": true
+        },
+        {
+          "type": "comparison_expression",
+          "named": true
+        },
+        {
+          "type": "conjunction_expression",
+          "named": true
+        },
+        {
+          "type": "disjunction_expression",
+          "named": true
+        },
+        {
+          "type": "elvis_expression",
+          "named": true
+        },
+        {
+          "type": "equality_expression",
+          "named": true
+        },
+        {
           "type": "function_body",
+          "named": true
+        },
+        {
+          "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "hex_literal",
+          "named": true
+        },
+        {
+          "type": "if_expression",
+          "named": true
+        },
+        {
+          "type": "indexing_expression",
+          "named": true
+        },
+        {
+          "type": "infix_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "jump_expression",
+          "named": true
+        },
+        {
+          "type": "lambda_literal",
+          "named": true
+        },
+        {
+          "type": "line_string_literal",
+          "named": true
+        },
+        {
+          "type": "long_literal",
+          "named": true
+        },
+        {
+          "type": "multi_line_string_literal",
+          "named": true
+        },
+        {
+          "type": "multiplicative_expression",
+          "named": true
+        },
+        {
+          "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
+          "type": "object_literal",
+          "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "parameter_modifiers",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "parenthesized_type",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_expression",
+          "named": true
+        },
+        {
+          "type": "range_expression",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "simple_identifier",
+          "named": true
+        },
+        {
+          "type": "spread_expression",
+          "named": true
+        },
+        {
+          "type": "super_expression",
+          "named": true
+        },
+        {
+          "type": "this_expression",
+          "named": true
+        },
+        {
+          "type": "try_expression",
           "named": true
         },
         {
@@ -226,6 +406,22 @@
         },
         {
           "type": "type_identifier",
+          "named": true
+        },
+        {
+          "type": "type_modifiers",
+          "named": true
+        },
+        {
+          "type": "unsigned_literal",
+          "named": true
+        },
+        {
+          "type": "user_type",
+          "named": true
+        },
+        {
+          "type": "when_expression",
           "named": true
         }
       ]
@@ -878,9 +1074,24 @@
     }
   },
   {
-    "type": "character_literal",
+    "type": "character_escape_seq",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "character_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "character_escape_seq",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "check_expression",
@@ -5128,6 +5339,10 @@
       "required": false,
       "types": [
         {
+          "type": "character_escape_seq",
+          "named": true
+        },
+        {
           "type": "interpolated_expression",
           "named": true
         },
@@ -9187,6 +9402,10 @@
     "named": false
   },
   {
+    "type": "!is",
+    "named": false
+  },
+  {
     "type": "\"",
     "named": false
   },
@@ -9328,6 +9547,10 @@
   },
   {
     "type": ">=",
+    "named": false
+  },
+  {
+    "type": "?.",
     "named": false
   },
   {

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -171,3 +171,106 @@ fun test() {
                 (simple_identifier))
               (value_argument
                 (simple_identifier)))))))))
+
+==================
+Anonymus function
+==================
+
+fun()
+val anon = fun()
+
+---
+
+(source_file
+  (anonymous_function)
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (anonymous_function)))
+
+==================
+Anonymus function with parameters
+==================
+
+fun(x: Int)
+val anon = fun(x: Int)
+
+---
+
+(source_file
+  (anonymous_function
+    (parameter
+      (simple_identifier)
+      (user_type
+        (type_identifier))))
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (anonymous_function
+      (parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier))))))
+
+==================
+Anonymus function with return type
+==================
+
+fun(): Int
+val anon = fun(): Int
+
+---
+
+(source_file
+  (anonymous_function
+    (user_type
+      (type_identifier)))
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (anonymous_function
+      (user_type
+        (type_identifier)))))
+
+==================
+Anonymus function with body
+==================
+
+fun() = true
+fun() { assert(true) }
+val anon = fun() = true
+val anon = fun() { assert(true) }
+
+---
+
+(source_file
+  (anonymous_function
+    (function_body
+      (boolean_literal)))
+  (anonymous_function
+    (function_body
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (boolean_literal))))))))
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (anonymous_function
+      (function_body
+        (boolean_literal))))
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (anonymous_function
+      (function_body
+        (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (boolean_literal))))))))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -107,13 +107,18 @@ assertEquals("\u214E\uA7B5\u2CEF", "\u2132\uA7B4\u2CEF".lowercase())
     (call_suffix
       (value_arguments
         (value_argument
-          (line_string_literal))
+          (line_string_literal
+            (character_escape_seq)
+            (character_escape_seq)
+            (character_escape_seq)))
         (value_argument
           (call_expression
             (navigation_expression
-              (line_string_literal)
+              (line_string_literal
+                (character_escape_seq)
+                (character_escape_seq)
+                (character_escape_seq))
               (navigation_suffix
                 (simple_identifier)))
             (call_suffix
               (value_arguments))))))))
-


### PR DESCRIPTION
As mentioned in #43, these grammar fixes are to allow for better and more expansive. querying. The only change not implemented was separating the labels from the `jump_expressions`, since an expression like `return@` causes a  conflict between `prefix_expression` and `return_expression`.