### PR TITLE
Improve ASI

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -163,7 +163,7 @@ module.exports = grammar({
 
     import_alias: $ => seq("as", alias($.simple_identifier, $.type_identifier)),
 
-    top_level_object: $ => seq($._declaration, optional($._semis)),
+    top_level_object: $ => seq($._declaration, optional($._semi)),
 
     type_alias: $ => seq(
       optional($.modifiers),
@@ -287,7 +287,7 @@ module.exports = grammar({
     // Class members
     // ==========
 
-    _class_member_declarations: $ => repeat1(seq($._class_member_declaration, $._semis)),
+    _class_member_declarations: $ => repeat1(seq($._class_member_declaration, $._semi)),
 
     _class_member_declaration: $ => choice(
       $._declaration,
@@ -514,8 +514,8 @@ module.exports = grammar({
 
     statements: $ => seq(
       $._statement,
-      repeat(seq($._semis, $._statement)),
-      optional($._semis),
+      repeat(seq($._semi, $._statement)),
+      optional($._semi),
     ),
 
     _statement: $ => choice(
@@ -576,8 +576,6 @@ module.exports = grammar({
     // See also https://github.com/tree-sitter/tree-sitter/issues/160
     // generic EOF/newline token
     _semi: $ => choice($._automatic_semicolon, ';'),
-
-    _semis: $ => choice($._automatic_semicolon, ';'),
 
     assignment: $ => choice(
       prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),
@@ -649,7 +647,7 @@ module.exports = grammar({
     elvis_expression: $ => prec.left(PREC.ELVIS, seq($._expression, "?:", $._expression)),
 
     check_expression: $ => prec.left(PREC.CHECK, seq($._expression, choice(
-      seq($._in_operator, $._expression), 
+      seq($._in_operator, $._expression),
       seq($._is_operator, $._type)))),
 
     comparison_expression: $ => prec.left(PREC.COMPARISON, seq($._expression, $._comparison_operator, $._expression)),
@@ -778,7 +776,7 @@ module.exports = grammar({
     lambda_parameters: $ => sep1($._lambda_parameter, ","),
 
     _lambda_parameter: $ => choice(
-      $.variable_declaration, 
+      $.variable_declaration,
       $.multi_variable_declaration
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -575,7 +575,7 @@ module.exports = grammar({
 
     // See also https://github.com/tree-sitter/tree-sitter/issues/160
     // generic EOF/newline token
-    _semi: $ => choice($._automatic_semicolon, ';'),
+    _semi: $ => $._automatic_semicolon,
 
     assignment: $ => choice(
       prec.left(PREC.ASSIGNMENT, seq($.directly_assignable_expression, $._assignment_and_operator, $._expression)),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -13,33 +13,34 @@ void tree_sitter_kotlin_external_scanner_reset(void *p) {}
 unsigned tree_sitter_kotlin_external_scanner_serialize(void *p, char *buffer) { return 0; }
 void tree_sitter_kotlin_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
 
+static void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
 static void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 
 static bool scan_whitespace_and_comments(TSLexer *lexer) {
   for (;;) {
     while (iswspace(lexer->lookahead)) {
-      advance(lexer);
+      skip(lexer);
     }
 
     if (lexer->lookahead == '/') {
-      advance(lexer);
+      skip(lexer);
 
       if (lexer->lookahead == '/') {
-        advance(lexer);
+        skip(lexer);
         while (lexer->lookahead != 0 && lexer->lookahead != '\n') {
-          advance(lexer);
+          skip(lexer);
         }
       } else if (lexer->lookahead == '*') {
-        advance(lexer);
+        skip(lexer);
         while (lexer->lookahead != 0) {
           if (lexer->lookahead == '*') {
-            advance(lexer);
+            skip(lexer);
             if (lexer->lookahead == '/') {
-              advance(lexer);
+              skip(lexer);
               break;
             }
           } else {
-            advance(lexer);
+            skip(lexer);
           }
         }
       } else {
@@ -66,34 +67,123 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
   lexer->result_symbol = AUTOMATIC_SEMICOLON;
   lexer->mark_end(lexer);
 
+  bool sameline = true;
   for (;;) {
-    if (!iswspace(lexer->lookahead)) return false;
-    if (lexer->lookahead == '\n') break;
-    // other whitespace (not newline)
-    advance(lexer);
-  }
-  // consume the '\n' from the break
-  advance(lexer);
+    if (lexer->eof(lexer))
+      return true;
 
-  if (!scan_whitespace_and_comments(lexer)) return false;
+    if (lexer->lookahead == ';') {
+      advance(lexer);
+      lexer->mark_end(lexer);
+      return true;
+    }
+
+    if (!iswspace(lexer->lookahead)) {
+      break;
+    }
+
+    if (lexer->lookahead == '\n') {
+      skip(lexer);
+
+      sameline = false;
+      break;
+    }
+
+    if (lexer->lookahead == '\r') {
+      skip(lexer);
+
+      if (lexer->lookahead == '\n') {
+        skip(lexer);
+      }
+
+      sameline = false;
+      break;
+    }
+
+    skip(lexer);
+  }
+
+  // Skip whitespace and comments
+  if (!scan_whitespace_and_comments(lexer))
+    return false;
+
+  if (sameline) {
+    switch (lexer->lookahead) {
+      case 'e':
+        return scan_for_word(lexer, "lse", 3);
+
+      case 'i':
+        return scan_for_word(lexer, "mport", 5);
+
+      case ';':
+        advance(lexer);
+        lexer->mark_end(lexer);
+        return true;
+
+      default:
+        return false;
+    }
+  }
 
   switch (lexer->lookahead) {
+    case ',':
+    case '.':
+    case ':':
+    case '*':
+    case '%':
+    case '>':
+    case '<':
+    case '=':
+    case '{':
+    case '[':
+    case '(':
+    case '?':
+    case '|':
+    case '&':
+    case '/':
+      return false;
+
+    // Insert a semicolon before `--` and `++`, but not before binary `+` or `-`.
+    // Insert before +/-Float
+    case '+':
+      skip(lexer);
+      if (lexer->lookahead == '+')
+        return true;
+      return iswdigit(lexer->lookahead);
+    case '-':
+      skip(lexer);
+      if (lexer->lookahead == '-')
+        return true;
+      return iswdigit(lexer->lookahead);
+
+    // Don't insert a semicolon before `!=`, but do insert one before a unary `!`.
+    case '!':
+      skip(lexer);
+      return lexer->lookahead != '=';
+
     // specific to Kotlin
     case 'e': // ex: else on next line after 'if' control body
       return scan_for_word(lexer, "lse", 3);
-    case '{': // ex: function body defined on next line after decl
 
-    // cases also in tree-sitter-javascript/src/scanner.c
-    case '.': // ex: method-chain calls on next line
-    case ':': // ex: inheritance clause defined on next line
-    case '=': // ex: fun/val definition on next line (or == binop)
-    case '?': // ex: elvis operator ?: on next line
-    case '^': // ex: binary operator between 2 exprs
-    case '|': // ex: binary operator between 2 exprs
-    case '&': // ex: binary operator between 2 exprs
+    // Don't insert a semicolon before `in` or `instanceof`, but do insert one
+    // before an identifier or an import.
+    case 'i':
+      skip(lexer);
+      if (lexer->lookahead != 'n')
+        return true;
 
-      return false;
+      skip(lexer);
+      if (!iswalpha(lexer->lookahead))
+        return false;
+
+      return scan_for_word(lexer, "stanceof", 8);
+
+      case ';':
+        advance(lexer);
+        lexer->mark_end(lexer);
+        return true;
+
+    default:
+      return true;
   }
-
-  return true;
 }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -210,4 +210,71 @@ foo.forEach { (index, value) -> 2 }
           (statements
             (integer_literal)))))))
 
+==================
+Multiple Statements on a Single Line
+==================
 
+fun main() { val temp = b.y; b.y = b.z; b.z = temp }
+
+when (dir) {
+  1 -> { val temp = b.y; b.y = b.z; b.z = temp }
+}
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_body
+      (statements
+        (property_declaration
+          (variable_declaration
+            (simple_identifier))
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier))))
+        (assignment
+          (directly_assignable_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier))))
+        (assignment
+          (directly_assignable_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))
+          (simple_identifier)))))
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (integer_literal))
+      (control_structure_body
+        (statements
+          (property_declaration
+            (variable_declaration
+              (simple_identifier))
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier))))
+          (assignment
+            (directly_assignable_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier)))
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier))))
+          (assignment
+            (directly_assignable_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier)))
+            (simple_identifier)))))))

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -173,3 +173,23 @@ else boo()
         (simple_identifier)
         (call_suffix
           (value_arguments))))))
+
+==================
+Else after newline
+==================
+
+if (!foo) 3 else boo()
+
+---
+
+(source_file
+  (if_expression
+    (prefix_expression
+      (simple_identifier))
+    (control_structure_body
+      (integer_literal))
+    (control_structure_body
+      (call_expression
+        (simple_identifier)
+        (call_suffix
+          (value_arguments))))))

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -47,3 +47,24 @@ Multiple file annotations
         (value_argument
           (callable_reference
             (type_identifier)))))))
+
+===================
+Multiple Imports On A Single Line
+===================
+
+import java.io.Path import java.io.Files
+
+---
+
+(source_file
+  (import_header
+    (identifier
+      (simple_identifier)
+      (simple_identifier)
+      (simple_identifier))
+    (MISSING _automatic_semicolon))
+  (import_header
+    (identifier
+      (simple_identifier)
+      (simple_identifier)
+      (simple_identifier))))

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -61,8 +61,7 @@ import java.io.Path import java.io.Files
     (identifier
       (simple_identifier)
       (simple_identifier)
-      (simple_identifier))
-    (MISSING _automatic_semicolon))
+      (simple_identifier)))
   (import_header
     (identifier
       (simple_identifier)


### PR DESCRIPTION
This pull request copies `tree-sitter-javascript`'s ASI code and modifies so that it can handle single line statements such as `import foo import baz` and `if (true) foo else bar`.

Furthermore it pushes the responsibility for matching semicolons to the ASI code instead of the generated tree-sitter parser.

Closes: #45