### PR TITLE
Separate when_expression body into it's own node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -847,6 +847,10 @@ module.exports = grammar({
     when_expression: $ => seq(
       "when",
       optional($.when_subject),
+      $.when_structure_body,
+    ),
+
+    when_structure_body: $ => seq(
       "{",
       repeat($.when_entry),
       "}"

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -95,11 +95,19 @@ val y = when(x){
   (property_declaration
     (variable_declaration (simple_identifier))
     (when_expression
-      (when_subject (simple_identifier))
-      (when_entry (when_condition (integer_literal))
-        (control_structure_body (boolean_literal)))
-      (when_entry (when_condition (integer_literal))
-        (control_structure_body (boolean_literal))))))
+      (when_subject
+	    (simple_identifier))
+	  (when_structure_body
+        (when_entry
+		  (when_condition
+		    (integer_literal))
+          (control_structure_body
+		    (boolean_literal)))
+        (when_entry
+		  (when_condition
+		    (integer_literal))
+          (control_structure_body
+		    (boolean_literal)))))))
 
 =================
 When expression with type arguments
@@ -115,15 +123,16 @@ when (this) {
   (when_expression
     (when_subject
       (this_expression))
-    (when_entry
-      (when_condition
-        (type_test
-          (user_type
-            (type_identifier)
-            (type_arguments
-              (type_projection)))))
-      (control_structure_body
-        (jump_expression)))))
+	(when_structure_body
+      (when_entry
+        (when_condition
+          (type_test
+            (user_type
+              (type_identifier)
+              (type_arguments
+                (type_projection)))))
+        (control_structure_body
+          (jump_expression))))))
 
 ==================
 Value declaration with receiver type
@@ -301,30 +310,31 @@ when (dir) {
   (when_expression
     (when_subject
       (simple_identifier))
-    (when_entry
-      (when_condition
-        (integer_literal))
-      (control_structure_body
-        (statements
-          (property_declaration
-            (variable_declaration
-              (simple_identifier))
-            (navigation_expression
-              (simple_identifier)
-              (navigation_suffix
-                (simple_identifier))))
-          (assignment
-            (directly_assignable_expression
-              (simple_identifier)
-              (navigation_suffix
-                (simple_identifier)))
-            (navigation_expression
-              (simple_identifier)
-              (navigation_suffix
-                (simple_identifier))))
-          (assignment
-            (directly_assignable_expression
-              (simple_identifier)
-              (navigation_suffix
-                (simple_identifier)))
-            (simple_identifier)))))))
+	(when_structure_body
+      (when_entry
+        (when_condition
+          (integer_literal))
+        (control_structure_body
+          (statements
+            (property_declaration
+              (variable_declaration
+                (simple_identifier))
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier))))
+            (assignment
+              (directly_assignable_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier))))
+            (assignment
+              (directly_assignable_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (simple_identifier))))))))


### PR DESCRIPTION
Moved the body of the when expression to a separate rule so that it can be queried separately. This also makes it consistent with the other kotlin control structures.

I left this commit out of #48 since it deviates from the [kotlin grammar reference](https://kotlinlang.org/docs/reference/grammar.html#anonymousFunction) and I wasn't sure that was a good idea or not.