### PR TITLE
Fixed package.json so it works with tree-sitter CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,15 @@
     "nan": "^2.15.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.20.0"
-  }
+    "tree-sitter-cli": "^0.20.6"
+  },
+  "tree-sitter": [
+    {   
+      "scope": "source.python",
+      "file-types": [
+        "kt"
+      ]   
+    }   
+  ]
+
 }


### PR DESCRIPTION
Current package.json doesn't have the tree sitter object. This means when it is used with tree-sitter CLI, tree-sitter CLI doesn't understand that kt is the Kotlin file extension, and doesn't find a parser. 

The patch adds the object and specifies the kt file extension. 