### PR TITLE
allow trailing comma in delegation specifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -250,11 +250,14 @@ module.exports = grammar({
       optional(seq("=", $._expression))
     ),
 
-    _delegation_specifiers: $ => prec.left(sep1(
-      $.delegation_specifier,
-      // $._annotated_delegation_specifier, // TODO: Annotations cause ambiguities with type modifiers
-      ","
-    )),
+    _delegation_specifiers: $ => prec.left(seq(
+       sep1(
+         $.delegation_specifier,
+         // $._annotated_delegation_specifier, // TODO: Annotations cause ambiguities with type m     odifiers
+         ","
+       ),
+       optional(",")
+     )),
 
     delegation_specifier: $ => prec.left(choice(
       $.constructor_invocation,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -729,24 +729,41 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "delegation_specifier"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "delegation_specifier"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "delegation_specifier"
+                    }
+                  ]
+                }
+              }
+            ]
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "delegation_specifier"
-                }
-              ]
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
+  const char **symbol_names;
+  const char **field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
So for instance, we may be dealing with a case like:
```
class Foo() : Bar(
  x = "hi",
  y = "bye",
) {
  // ...
}
```
Currently, we do not allow the trailing comma in the delegation specifiers.