### PR TITLE
revert erroneous commit and add trailing comma for constructors

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -698,7 +698,16 @@ module.exports = grammar({
 
     type_arguments: $ => seq("<", sep1($.type_projection, ","), ">"),
 
-    value_arguments: $ => seq("(", optional(sep1($.value_argument, ",")), ")"),
+    value_arguments: $ => seq(
+      "(", 
+      optional(
+        seq(
+          sep1($.value_argument, ","),
+          optional(","),
+        )
+      ),
+      ")"
+    ),
 
     value_argument: $ => seq(
       optional($.annotation),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3470,24 +3470,41 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "value_argument"
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "value_argument"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "value_argument"
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "value_argument"
-                      }
-                    ]
-                  }
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
             },

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
+  const char **symbol_names;
+  const char **field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -174,3 +174,22 @@ a as T.() -> Unit
       (function_type_parameters)
       (user_type (type_identifier)))))
 
+==================
+Type constructor
+==================
+
+a as Foo(x = "hi", y = "bar")
+
+---
+
+(source_file (call_expression (as_expression (simple_identifier) (user_type (type_identifier))) (call_suffix (value_arguments (value_argument (simple_identifier) (line_string_literal)) (value_argument (simple_identifier) (line_string_literal)))))) 
+
+==================
+Type constructor with trailing comma
+==================
+
+a as Foo(x = "hi", y = "bar",)
+
+---
+
+(source_file (call_expression (as_expression (simple_identifier) (user_type (type_identifier))) (call_suffix (value_arguments (value_argument (simple_identifier) (line_string_literal)) (value_argument (simple_identifier) (line_string_literal)))))) 


### PR DESCRIPTION
Oops. Turns out, the commit I made earlier (#61) was wrong.

I don't want the comma on the delegation specifiers, I want it on the constructors. I've added some tests to reflect this, sorry.

@fwcd 