### PR TITLE
chore: add more examples

### DIFF
--- a/examples/Delegates.kt
+++ b/examples/Delegates.kt
@@ -1,0 +1,14 @@
+// Taken from Kotlin 1.7
+// https://kotlinlang.org/docs/whatsnew17.html#underscore-operator-for-type-arguments
+
+interface Bar {
+    fun foo() = "foo"
+}
+
+@JvmInline
+value class BarWrapper(val bar: Bar): Bar by bar
+
+fun main() {
+    val bw = BarWrapper(object: Bar {})
+    println(bw.foo())
+}

--- a/examples/Elvis.kt
+++ b/examples/Elvis.kt
@@ -1,0 +1,15 @@
+fun <T> elvisLike(x: T, y: T & Any): T & Any = x ?: y
+
+fun main() {
+    // OK
+    elvisLike<String>("", "").length
+
+    // Error: 'null' cannot be a value of a non-null type
+    elvisLike<String>("", null).length
+
+    // OK
+    elvisLike<String?>(null, "").length
+
+    // Error: 'null' cannot be a value of a non-null type
+    elvisLike<String?>(null, null).length
+}

--- a/examples/UnderscoreOperator.kt
+++ b/examples/UnderscoreOperator.kt
@@ -1,0 +1,30 @@
+// Taken from Kotlin 1.7
+// https://kotlinlang.org/docs/whatsnew17.html#underscore-operator-for-type-arguments
+
+abstract class SomeClass<T> {
+    abstract fun execute(): T
+}
+
+class SomeImplementation : SomeClass<String>() {
+    override fun execute(): String = "Test"
+}
+
+class OtherImplementation : SomeClass<Int>() {
+    override fun execute(): Int = 42
+}
+
+object Runner {
+    inline fun <reified S: SomeClass<T>, T> run(): T {
+        return S::class.java.getDeclaredConstructor().newInstance().execute()
+    }
+}
+
+fun main() {
+    // T is inferred as String because SomeImplementation derives from SomeClass<String>
+    val s = Runner.run<SomeImplementation, _>()
+    assert(s == "Test")
+
+    // T is inferred as Int because OtherImplementation derives from SomeClass<Int>
+    val n = Runner.run<OtherImplementation, _>()
+    assert(n == 42)
+}


### PR DESCRIPTION
Adds some more examples from Kotlin 1.7.

See https://kotlinlang.org/docs/whatsnew17.html#underscore-operator-for-type-arguments


