### PR TITLE
Exposing `block` in the parse tree

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -306,7 +306,7 @@ module.exports = grammar({
       $.secondary_constructor
     ),
 
-    anonymous_initializer: $ => seq("init", $._block),
+    anonymous_initializer: $ => seq("init", $.block),
 
     companion_object: $ => seq(
       optional($.modifiers),
@@ -351,7 +351,7 @@ module.exports = grammar({
       optional($.function_body)
     )),
 
-    function_body: $ => choice($._block, seq("=", $._expression)),
+    function_body: $ => choice($.block, seq("=", $._expression)),
 
     variable_declaration: $ => prec.left(PREC.VAR_DECL, seq(
       // repeat($.annotation), TODO
@@ -425,7 +425,7 @@ module.exports = grammar({
       "constructor",
       $._function_value_parameters,
       optional(seq(":", $.constructor_delegation_call)),
-      optional($._block)
+      optional($.block)
     ),
 
     constructor_delegation_call: $ => seq(choice("this", "super"), $.value_arguments),
@@ -545,9 +545,9 @@ module.exports = grammar({
       "@"
     )),
 
-    control_structure_body: $ => choice($._block, $._statement),
+    control_structure_body: $ => choice($.block, $._statement),
 
-    _block: $ => prec(PREC.BLOCK, seq("{", optional($.statements), "}")),
+    block: $ => prec(PREC.BLOCK, seq("{", optional($.statements), "}")),
 
     _loop_statement: $ => choice(
       $.for_statement,
@@ -883,7 +883,7 @@ module.exports = grammar({
 
     try_expression: $ => seq(
       "try",
-      $._block,
+      $.block,
       choice(
         seq(repeat1($.catch_block), optional($.finally_block)),
         $.finally_block
@@ -898,10 +898,10 @@ module.exports = grammar({
       ":",
       $._type,
       ")",
-      $._block,
+      $.block,
     ),
 
-    finally_block: $ => seq("finally", $._block),
+    finally_block: $ => seq("finally", $.block),
 
     jump_expression: $ => choice(
       prec.right(PREC.RETURN_OR_THROW, seq("throw", $._expression)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1029,7 +1029,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_block"
+          "name": "block"
         }
       ]
     },
@@ -1366,7 +1366,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_block"
+          "name": "block"
         },
         {
           "type": "SEQ",
@@ -1960,7 +1960,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_block"
+              "name": "block"
             },
             {
               "type": "BLANK"
@@ -2562,7 +2562,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_block"
+          "name": "block"
         },
         {
           "type": "SYMBOL",
@@ -2570,7 +2570,7 @@
         }
       ]
     },
-    "_block": {
+    "block": {
       "type": "PREC",
       "value": 1,
       "content": {
@@ -4450,7 +4450,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_block"
+          "name": "block"
         },
         {
           "type": "CHOICE",
@@ -4523,7 +4523,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_block"
+          "name": "block"
         }
       ]
     },
@@ -4536,7 +4536,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_block"
+          "name": "block"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -433,10 +433,10 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
-          "type": "statements",
+          "type": "block",
           "named": true
         }
       ]
@@ -809,6 +809,21 @@
     }
   },
   {
+    "type": "block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "statements",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "boolean_literal",
     "named": true,
     "fields": {}
@@ -1043,6 +1058,10 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "function_type",
           "named": true
         },
@@ -1056,10 +1075,6 @@
         },
         {
           "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "statements",
           "named": true
         },
         {
@@ -2185,6 +2200,10 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "boolean_literal",
           "named": true
         },
@@ -2342,10 +2361,6 @@
         },
         {
           "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "statements",
           "named": true
         },
         {
@@ -3491,10 +3506,10 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
-          "type": "statements",
+          "type": "block",
           "named": true
         }
       ]
@@ -3712,6 +3727,10 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "boolean_literal",
           "named": true
         },
@@ -3833,10 +3852,6 @@
         },
         {
           "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "statements",
           "named": true
         },
         {
@@ -7372,6 +7387,10 @@
           "named": true
         },
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "boolean_literal",
           "named": true
         },
@@ -7509,10 +7528,6 @@
         },
         {
           "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "statements",
           "named": true
         },
         {
@@ -8243,15 +8258,15 @@
       "required": true,
       "types": [
         {
+          "type": "block",
+          "named": true
+        },
+        {
           "type": "catch_block",
           "named": true
         },
         {
           "type": "finally_block",
-          "named": true
-        },
-        {
-          "type": "statements",
           "named": true
         }
       ]

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -23,13 +23,14 @@ class Foo(){
           (simple_identifier)
           (user_type
             (type_identifier)))
-        (statements
-          (assignment
-            (directly_assignable_expression
-              (this_expression)
-              (navigation_suffix
-                (simple_identifier)))
-            (simple_identifier)))))))
+        (block
+          (statements
+            (assignment
+              (directly_assignable_expression
+                (this_expression)
+                (navigation_suffix
+                  (simple_identifier)))
+              (simple_identifier))))))))
 
 ==================
 Index Assignment
@@ -46,19 +47,20 @@ fun main(){
   (function_declaration
     (simple_identifier)
     (function_body
-      (statements
-        (property_declaration
-          (variable_declaration
-            (simple_identifier)
-            (user_type
-              (type_identifier)
-              (type_arguments
-                (type_projection
-                  (user_type
-                    (type_identifier)))))))
-        (assignment
-          (directly_assignable_expression
-            (simple_identifier)
-            (indexing_suffix
-              (integer_literal)))
-          (line_string_literal))))))
+      (block
+        (statements
+          (property_declaration
+            (variable_declaration
+              (simple_identifier)
+              (user_type
+                (type_identifier)
+                (type_arguments
+                  (type_projection
+                    (user_type
+                      (type_identifier)))))))
+          (assignment
+            (directly_assignable_expression
+              (simple_identifier)
+              (indexing_suffix
+                (integer_literal)))
+            (line_string_literal)))))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -26,8 +26,8 @@ class HelloWorld {
 (source_file
   (class_declaration (type_identifier)
     (class_body
-      (function_declaration (simple_identifier) (function_body))
-      (function_declaration (simple_identifier) (function_body)))))
+      (function_declaration (simple_identifier) (function_body (block)))
+      (function_declaration (simple_identifier) (function_body (block))))))
 
 ==================
 Generic class

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -275,36 +275,7 @@ when (dir) {
   (function_declaration
     (simple_identifier)
     (function_body
-      (statements
-        (property_declaration
-          (variable_declaration
-            (simple_identifier))
-          (navigation_expression
-            (simple_identifier)
-            (navigation_suffix
-              (simple_identifier))))
-        (assignment
-          (directly_assignable_expression
-            (simple_identifier)
-            (navigation_suffix
-              (simple_identifier)))
-          (navigation_expression
-            (simple_identifier)
-            (navigation_suffix
-              (simple_identifier))))
-        (assignment
-          (directly_assignable_expression
-            (simple_identifier)
-            (navigation_suffix
-              (simple_identifier)))
-          (simple_identifier)))))
-  (when_expression
-    (when_subject
-      (simple_identifier))
-    (when_entry
-      (when_condition
-        (integer_literal))
-      (control_structure_body
+      (block
         (statements
           (property_declaration
             (variable_declaration
@@ -327,4 +298,35 @@ when (dir) {
               (simple_identifier)
               (navigation_suffix
                 (simple_identifier)))
-            (simple_identifier)))))))
+            (simple_identifier))))))
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (integer_literal))
+      (control_structure_body
+        (block
+          (statements
+            (property_declaration
+              (variable_declaration
+                (simple_identifier))
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier))))
+            (assignment
+              (directly_assignable_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier))))
+            (assignment
+              (directly_assignable_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (simple_identifier))))))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -9,7 +9,7 @@ fun main() {}
 (source_file
   (function_declaration
     (simple_identifier)
-    (function_body)))
+    (function_body (block))))
 
 ==================
 Generic functions
@@ -23,7 +23,7 @@ fun <T> test() {}
   (function_declaration
     (type_parameters (type_parameter (type_identifier)))
     (simple_identifier)
-    (function_body)))
+    (function_body (block))))
 
 ==================
 Generic functions with parameters
@@ -46,7 +46,7 @@ fun <T: Int> bar(foo: Int): T {}
         (type_identifier)))
     (user_type
       (type_identifier))
-    (function_body)))
+    (function_body (block))))
 
 ==================
 Functions with parameters
@@ -66,7 +66,7 @@ fun sum(a: Int, b: Int) = a + b
       (user_type
         (type_identifier)
         (type_arguments (type_projection (user_type (type_identifier))))))
-    (function_body))
+    (function_body (block)))
   (function_declaration
     (simple_identifier)
     (parameter
@@ -114,15 +114,16 @@ fun foo(p0: Int): Long {
     (user_type
       (type_identifier))
     (function_body
-      (statements
-        (jump_expression
-          (call_expression
-            (navigation_expression
-              (simple_identifier)
-              (navigation_suffix
-                (simple_identifier)))
-            (call_suffix
-              (value_arguments))))))))
+      (block
+        (statements
+          (jump_expression
+            (call_expression
+              (navigation_expression
+                (simple_identifier)
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments)))))))))
 
 =====================
 Override functions
@@ -158,19 +159,20 @@ fun test() {
   (function_declaration
     (simple_identifier)
     (function_body
-      (statements
-        (assignment
-          (directly_assignable_expression
-            (simple_identifier))
-          (boolean_literal))
-        (call_expression
-          (simple_identifier)
-          (call_suffix
-            (value_arguments
-              (value_argument
-                (simple_identifier))
-              (value_argument
-                (simple_identifier)))))))))
+      (block
+        (statements
+          (assignment
+            (directly_assignable_expression
+              (simple_identifier))
+            (boolean_literal))
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (simple_identifier))
+                (value_argument
+                  (simple_identifier))))))))))
 
 ==================
 Anonymous function
@@ -249,13 +251,14 @@ val anon = fun() { assert(true) }
       (boolean_literal)))
   (anonymous_function
     (function_body
-      (statements
-        (call_expression
-          (simple_identifier)
-          (call_suffix
-            (value_arguments
-              (value_argument
-                (boolean_literal))))))))
+      (block
+        (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (boolean_literal)))))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -267,10 +270,11 @@ val anon = fun() { assert(true) }
       (simple_identifier))
     (anonymous_function
       (function_body
-        (statements
-          (call_expression
-            (simple_identifier)
-            (call_suffix
-              (value_arguments
-                (value_argument
-                  (boolean_literal))))))))))
+        (block
+          (statements
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (boolean_literal)))))))))))

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -43,10 +43,11 @@ fun foo()  {
 (source_file
   (function_declaration (simple_identifier)
      (function_body
-        (statements
-           (property_declaration
-              (variable_declaration (simple_identifier))
-              (conjunction_expression (simple_identifier) (simple_identifier)))))))
+        (block
+          (statements
+             (property_declaration
+                (variable_declaration (simple_identifier))
+                (conjunction_expression (simple_identifier) (simple_identifier))))))))
 
 
 ==================
@@ -60,7 +61,9 @@ fun foo():String
 (source_file
    (function_declaration (simple_identifier)
       (user_type (type_identifier))
-      (function_body (statements (jump_expression (line_string_literal))))))
+      (function_body
+        (block
+          (statements (jump_expression (line_string_literal)))))))
 
 ==================
 Colon after newline
@@ -93,21 +96,22 @@ fun foo() {
 (source_file
   (function_declaration (simple_identifier)
     (function_body
-      (statements
-        (property_declaration
-          (variable_declaration (simple_identifier))
-            (elvis_expression
+      (block
+        (statements
+          (property_declaration
+            (variable_declaration (simple_identifier))
               (elvis_expression
-                (call_expression
-                   (navigation_expression (simple_identifier)
-                     (navigation_suffix (simple_identifier)))
-                   (call_suffix
-                     (value_arguments (value_argument (boolean_literal)))))
-                (call_expression
-                   (navigation_expression (simple_identifier)
-                      (navigation_suffix (simple_identifier)))
-                    (call_suffix (value_arguments))))
-               (jump_expression)))))))
+                (elvis_expression
+                  (call_expression
+                     (navigation_expression (simple_identifier)
+                       (navigation_suffix (simple_identifier)))
+                     (call_suffix
+                       (value_arguments (value_argument (boolean_literal)))))
+                  (call_expression
+                     (navigation_expression (simple_identifier)
+                        (navigation_suffix (simple_identifier)))
+                      (call_suffix (value_arguments))))
+                 (jump_expression))))))))
 
 ==================
 get after newline

--- a/test/corpus/soft_keywords.txt
+++ b/test/corpus/soft_keywords.txt
@@ -12,12 +12,13 @@ fun foo() {
 (source_file
   (function_declaration (simple_identifier)
     (function_body
-      (statements
-         (property_declaration
-	   (variable_declaration (simple_identifier))
-	   (call_expression (simple_identifier)
-	     (call_suffix
-	       (value_arguments (value_argument (simple_identifier))))))
-	 (postfix_expression
-	    (indexing_expression (simple_identifier)
-  	      (indexing_suffix (integer_literal))))))))
+      (block
+        (statements
+          (property_declaration
+            (variable_declaration (simple_identifier))
+            (call_expression (simple_identifier)
+              (call_suffix
+              (value_arguments (value_argument (simple_identifier))))))
+          (postfix_expression
+            (indexing_expression (simple_identifier)
+  	          (indexing_suffix (integer_literal)))))))))

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -87,7 +87,7 @@ fun main() {
         (simple_identifier))))
   (function_declaration
     (simple_identifier)
-    (function_body)))
+    (function_body (block))))
 
 ===================
 Multiple Imports On A Single Line

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -10,7 +10,8 @@ for (value in values) {}
   (for_statement
     (variable_declaration (simple_identifier))
     (simple_identifier)
-    (control_structure_body)))
+    (control_structure_body
+      (block))))
 
 ==================
 Statements separated by semicolon
@@ -28,11 +29,12 @@ override fun isDisposed(): Boolean { expectUnreached();  return false }
     (user_type
       (type_identifier))
     (function_body
-      (statements
-        (call_expression
-          (simple_identifier)
-          (call_suffix
-            (value_arguments)))
-        (jump_expression
-          (boolean_literal))))))
+      (block
+        (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments)))
+          (jump_expression
+            (boolean_literal)))))))
 


### PR DESCRIPTION
This makes writing indentation code for Kotlin much easier, because we can simply identify wherever a block exists.