### PR TITLE
Expose function_value_parameters

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -323,7 +323,7 @@ module.exports = grammar({
       optional($.class_body)
     ),
 
-    _function_value_parameters: $ => seq(
+    function_value_parameters: $ => seq(
       "(",
       optional(sep1($._function_value_parameter, ",")),
       optional(","),
@@ -351,7 +351,7 @@ module.exports = grammar({
       optional($.type_parameters),
       optional(seq($._receiver_type, optional('.'))),
       $.simple_identifier,
-      $._function_value_parameters,
+      $.function_value_parameters,
       optional(seq(":", $._type)),
       optional($.type_constraints),
       optional($.function_body)
@@ -429,7 +429,7 @@ module.exports = grammar({
     secondary_constructor: $ => seq(
       optional($.modifiers),
       "constructor",
-      $._function_value_parameters,
+      $.function_value_parameters,
       optional(seq(":", $.constructor_delegation_call)),
       optional($._block)
     ),
@@ -791,7 +791,7 @@ module.exports = grammar({
     anonymous_function: $ => prec.right(seq(
       "fun",
       optional(seq(sep1($._simple_user_type, "."), ".")), // TODO
-      $._function_value_parameters,
+      $.function_value_parameters,
       optional(seq(":", $._type)),
       optional($.function_body)
     )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1120,7 +1120,7 @@
         }
       ]
     },
-    "_function_value_parameters": {
+    "function_value_parameters": {
       "type": "SEQ",
       "members": [
         {
@@ -1323,7 +1323,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_function_value_parameters"
+            "name": "function_value_parameters"
           },
           {
             "type": "CHOICE",
@@ -1944,7 +1944,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_function_value_parameters"
+          "name": "function_value_parameters"
         },
         {
           "type": "CHOICE",
@@ -4016,7 +4016,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_function_value_parameters"
+            "name": "function_value_parameters"
           },
           {
             "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -218,68 +218,8 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
         {
           "type": "function_body",
           "named": true
@@ -289,43 +229,7 @@
           "named": true
         },
         {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
+          "type": "function_value_parameters",
           "named": true
         },
         {
@@ -333,63 +237,7 @@
           "named": true
         },
         {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parameter",
-          "named": true
-        },
-        {
-          "type": "parameter_modifiers",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
           "type": "parenthesized_type",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
           "named": true
         },
         {
@@ -405,15 +253,7 @@
           "named": true
         },
         {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
           "type": "user_type",
-          "named": true
-        },
-        {
-          "type": "when_expression",
           "named": true
         }
       ]
@@ -3795,66 +3635,6 @@
       "required": true,
       "types": [
         {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
           "type": "function_body",
           "named": true
         },
@@ -3863,35 +3643,7 @@
           "named": true
         },
         {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
+          "type": "function_value_parameters",
           "named": true
         },
         {
@@ -3899,31 +3651,7 @@
           "named": true
         },
         {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
           "type": "nullable_type",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parameter",
-          "named": true
-        },
-        {
-          "type": "parameter_modifiers",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
           "named": true
         },
         {
@@ -3931,43 +3659,7 @@
           "named": true
         },
         {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
           "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
           "named": true
         },
         {
@@ -3983,15 +3675,7 @@
           "named": true
         },
         {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
           "type": "user_type",
-          "named": true
-        },
-        {
-          "type": "when_expression",
           "named": true
         }
       ]
@@ -4075,6 +3759,181 @@
         },
         {
           "type": "user_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_value_parameters",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "additive_expression",
+          "named": true
+        },
+        {
+          "type": "anonymous_function",
+          "named": true
+        },
+        {
+          "type": "as_expression",
+          "named": true
+        },
+        {
+          "type": "bin_literal",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "callable_reference",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "check_expression",
+          "named": true
+        },
+        {
+          "type": "collection_literal",
+          "named": true
+        },
+        {
+          "type": "comparison_expression",
+          "named": true
+        },
+        {
+          "type": "conjunction_expression",
+          "named": true
+        },
+        {
+          "type": "disjunction_expression",
+          "named": true
+        },
+        {
+          "type": "elvis_expression",
+          "named": true
+        },
+        {
+          "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "hex_literal",
+          "named": true
+        },
+        {
+          "type": "if_expression",
+          "named": true
+        },
+        {
+          "type": "indexing_expression",
+          "named": true
+        },
+        {
+          "type": "infix_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "jump_expression",
+          "named": true
+        },
+        {
+          "type": "lambda_literal",
+          "named": true
+        },
+        {
+          "type": "long_literal",
+          "named": true
+        },
+        {
+          "type": "multiplicative_expression",
+          "named": true
+        },
+        {
+          "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "object_literal",
+          "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
+        },
+        {
+          "type": "parameter_modifiers",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_expression",
+          "named": true
+        },
+        {
+          "type": "range_expression",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "simple_identifier",
+          "named": true
+        },
+        {
+          "type": "spread_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "super_expression",
+          "named": true
+        },
+        {
+          "type": "this_expression",
+          "named": true
+        },
+        {
+          "type": "try_expression",
+          "named": true
+        },
+        {
+          "type": "unsigned_literal",
+          "named": true
+        },
+        {
+          "type": "when_expression",
           "named": true
         }
       ]
@@ -7171,102 +7030,14 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
         {
           "type": "constructor_delegation_call",
           "named": true
         },
         {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
+          "type": "function_value_parameters",
           "named": true
         },
         {
@@ -7274,79 +7045,7 @@
           "named": true
         },
         {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parameter",
-          "named": true
-        },
-        {
-          "type": "parameter_modifiers",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
           "type": "statements",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
-          "named": true
-        },
-        {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "when_expression",
           "named": true
         }
       ]

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -89,6 +89,7 @@ class X {
           (annotation (user_type (type_identifier)))
           (annotation (user_type (type_identifier))))
         (simple_identifier)
+        (function_value_parameters)
         (user_type (type_identifier))
       )
     )
@@ -111,6 +112,7 @@ fun foo() = bar {}
         (user_type
           (type_identifier))))
     (simple_identifier)
+    (function_value_parameters)
     (function_body
       (call_expression
         (simple_identifier)

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -20,10 +20,11 @@ class Foo(){
         (variable_declaration
           (simple_identifier)))
       (secondary_constructor
+      (function_value_parameters
         (parameter
           (simple_identifier)
           (user_type
-            (type_identifier)))
+            (type_identifier))))
         (statements
           (assignment
             (directly_assignable_expression
@@ -46,6 +47,7 @@ fun main(){
 (source_file
   (function_declaration
     (simple_identifier)
+    (function_value_parameters)
     (function_body
       (statements
         (property_declaration

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -31,11 +31,13 @@ class HelloWorld {
     (type_identifier)
     (class_body
       (function_declaration
-        (simple_identifier)
-        (function_body))
+       (simple_identifier)
+       (function_value_parameters)
+       (function_body))
       (function_declaration
-        (simple_identifier)
-        (function_body)))))
+       (simple_identifier)
+       (function_value_parameters)
+       (function_body)))))
 
 ================================================================================
 Generic class
@@ -70,14 +72,16 @@ class Strings {
     (type_identifier)
     (class_body
       (function_declaration
-        (simple_identifier)
-        (function_body
-          (string_literal)))
+       (simple_identifier)
+       (function_value_parameters)
+       (function_body
+        (string_literal)))
       (function_declaration
-        (simple_identifier)
-        (function_body
+       (simple_identifier)
+       (function_value_parameters)
+       (function_body
+        (additive_expression
           (additive_expression
-            (additive_expression
               (string_literal)
               (string_literal))
             (string_literal)))))))
@@ -101,10 +105,11 @@ internal open class Test {
     (class_body
       (function_declaration
         (modifiers
-          (visibility_modifier)
-          (inheritance_modifier)
-          (function_modifier))
-        (simple_identifier)))))
+         (visibility_modifier)
+         (inheritance_modifier)
+         (function_modifier))
+        (simple_identifier)
+        (function_value_parameters)))))
 
 ================================================================================
 Objects
@@ -121,7 +126,8 @@ object Singleton {
     (type_identifier)
     (class_body
       (function_declaration
-        (simple_identifier)))))
+       (simple_identifier)
+       (function_value_parameters)))))
 
 ================================================================================
 Primary constructors
@@ -250,7 +256,7 @@ class Test(x: Int, y: Int) {
         (user_type
           (type_identifier))))
     (class_body
-      (secondary_constructor
+      (secondary_constructor (function_value_parameters)
         (constructor_delegation_call
           (value_arguments
             (value_argument
@@ -315,6 +321,7 @@ enum class Color(val rgb: Int) {
         (modifiers
           (member_modifier))
         (simple_identifier)
+        (function_value_parameters)
         (function_body
           (call_expression
             (navigation_expression

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -212,8 +212,8 @@ expect fun randomUUID(): String
     (modifiers
       (platform_modifier))
     (simple_identifier)
-    (user_type
-      (type_identifier))))
+    (function_value_parameters)
+    (user_type (type_identifier))))
 
 ================================================================================
 Less than for generics
@@ -346,6 +346,7 @@ when (dir) {
 (source_file
   (function_declaration
     (simple_identifier)
+    (function_value_parameters)
     (function_body
       (statements
         (property_declaration

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -8,7 +8,7 @@ fun main() {}
 
 (source_file
   (function_declaration
-    (simple_identifier)
+    (simple_identifier) (function_value_parameters)
     (function_body)))
 
 ==================
@@ -22,7 +22,7 @@ fun <T> test() {}
 (source_file
   (function_declaration
     (type_parameters (type_parameter (type_identifier)))
-    (simple_identifier)
+    (simple_identifier) (function_value_parameters)
     (function_body)))
 
 ==================
@@ -40,10 +40,11 @@ fun <T: Int> bar(foo: Int): T {}
         (user_type
           (type_identifier))))
     (simple_identifier)
-    (parameter
-      (simple_identifier)
-      (user_type
-        (type_identifier)))
+    (function_value_parameters
+      (parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier))))
     (user_type
       (type_identifier))
     (function_body)))
@@ -61,20 +62,22 @@ fun sum(a: Int, b: Int) = a + b
 (source_file
   (function_declaration
     (simple_identifier)
-    (parameter
-      (simple_identifier)
-      (user_type
-        (type_identifier)
-        (type_arguments (type_projection (user_type (type_identifier))))))
+    (function_value_parameters
+      (parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier)
+          (type_arguments (type_projection (user_type (type_identifier)))))))
     (function_body))
   (function_declaration
     (simple_identifier)
-    (parameter
-      (simple_identifier)
-      (user_type (type_identifier)))
-    (parameter
-      (simple_identifier)
-      (user_type (type_identifier)))
+    (function_value_parameters
+      (parameter
+        (simple_identifier)
+        (user_type (type_identifier)))
+      (parameter
+        (simple_identifier)
+        (user_type (type_identifier))))
     (function_body
       (additive_expression
         (simple_identifier)
@@ -91,6 +94,7 @@ fun answerToTheUltimateQuestionOfLifeTheUniverseAndEverything(): Int = 42
 (source_file
   (function_declaration
     (simple_identifier)
+    (function_value_parameters)
     (user_type (type_identifier))
     (function_body (integer_literal))))
 
@@ -107,10 +111,11 @@ fun foo(p0: Int): Long {
 (source_file
   (function_declaration
     (simple_identifier)
+    (function_value_parameters
     (parameter
       (simple_identifier)
       (user_type
-        (type_identifier)))
+        (type_identifier))))
     (user_type
       (type_identifier))
     (function_body
@@ -137,6 +142,7 @@ override fun boo() = foo()
     (modifiers
       (member_modifier))
     (simple_identifier)
+    (function_value_parameters)
     (function_body
       (call_expression
         (simple_identifier)
@@ -157,6 +163,7 @@ fun test() {
 (source_file
   (function_declaration
     (simple_identifier)
+    (function_value_parameters)
     (function_body
       (statements
         (assignment
@@ -182,11 +189,12 @@ val anon = fun()
 ---
 
 (source_file
-  (anonymous_function)
+  (anonymous_function
+  (function_value_parameters))
   (property_declaration
     (variable_declaration
       (simple_identifier))
-    (anonymous_function)))
+    (anonymous_function (function_value_parameters))))
 
 ==================
 Anonymous function with parameters
@@ -199,18 +207,20 @@ val anon = fun(x: Int)
 
 (source_file
   (anonymous_function
+  (function_value_parameters
     (parameter
       (simple_identifier)
       (user_type
-        (type_identifier))))
+        (type_identifier)))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
     (anonymous_function
+    (function_value_parameters
       (parameter
         (simple_identifier)
         (user_type
-          (type_identifier))))))
+          (type_identifier)))))))
 
 ==================
 Anonymous function with return type
@@ -223,12 +233,14 @@ val anon = fun(): Int
 
 (source_file
   (anonymous_function
+    (function_value_parameters)
     (user_type
       (type_identifier)))
   (property_declaration
     (variable_declaration
       (simple_identifier))
     (anonymous_function
+      (function_value_parameters)
       (user_type
         (type_identifier)))))
 
@@ -245,9 +257,11 @@ val anon = fun() { assert(true) }
 
 (source_file
   (anonymous_function
+    (function_value_parameters)
     (function_body
       (boolean_literal)))
   (anonymous_function
+    (function_value_parameters)
     (function_body
       (statements
         (call_expression
@@ -260,12 +274,14 @@ val anon = fun() { assert(true) }
     (variable_declaration
       (simple_identifier))
     (anonymous_function
+      (function_value_parameters)
       (function_body
         (boolean_literal))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
     (anonymous_function
+      (function_value_parameters)
       (function_body
         (statements
           (call_expression
@@ -284,4 +300,7 @@ fun `this is a test function`() = true
 ---
 
 (source_file
-  (function_declaration (simple_identifier) (function_body (boolean_literal))))
+  (function_declaration
+   (simple_identifier)
+   (function_value_parameters)
+   (function_body (boolean_literal))))

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -29,13 +29,13 @@ Eq after newline
 fun foo()
     = 1
 
---------------------------------------------------------------------------------
-
+---
 (source_file
-  (function_declaration
+   (function_declaration
     (simple_identifier)
-    (function_body
-      (integer_literal))))
+    (function_value_parameters)
+    (function_body 
+    (integer_literal))))
 
 ================================================================================
 Binary operator after newline
@@ -50,16 +50,15 @@ fun foo()  {
 --------------------------------------------------------------------------------
 
 (source_file
-  (function_declaration
-    (simple_identifier)
-    (function_body
-      (statements
-        (property_declaration
-          (variable_declaration
-            (simple_identifier))
-          (conjunction_expression
-            (simple_identifier)
-            (simple_identifier)))))))
+  (function_declaration (simple_identifier) (function_value_parameters)
+     (function_body
+        (statements
+           (property_declaration
+              (variable_declaration
+               (simple_identifier))
+              (conjunction_expression
+               (simple_identifier)
+               (simple_identifier)))))))
 
 ================================================================================
 Open brace after newline
@@ -68,11 +67,12 @@ Open brace after newline
 fun foo():String
     { return "bar"}
 
---------------------------------------------------------------------------------
+---
 
 (source_file
   (function_declaration
     (simple_identifier)
+    (function_value_parameters)
     (user_type
       (type_identifier))
     (function_body
@@ -113,7 +113,8 @@ fun foo() {
 
 (source_file
   (function_declaration
-    (simple_identifier)
+   (simple_identifier)
+  (function_value_parameters)
     (function_body
       (statements
         (property_declaration

--- a/test/corpus/soft_keywords.txt
+++ b/test/corpus/soft_keywords.txt
@@ -10,7 +10,7 @@ fun foo() {
 
 ---
 (source_file
-  (function_declaration (simple_identifier)
+  (function_declaration (simple_identifier) (function_value_parameters)
     (function_body
       (statements
          (property_declaration

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -90,6 +90,7 @@ fun main() {
         (simple_identifier))))
   (function_declaration
     (simple_identifier)
+    (function_value_parameters)
     (function_body)))
 
 ================================================================================

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -26,6 +26,7 @@ override fun isDisposed(): Boolean { expectUnreached();  return false }
     (modifiers
       (member_modifier))
     (simple_identifier)
+    (function_value_parameters)
     (user_type
       (type_identifier))
     (function_body


### PR DESCRIPTION
This PR exposes the `function_value_parameters` node. This makes it easier to write query the signature of the function like this: 
```
(
  (function_declaration (simple_identifier) @name
  (function_value_parameters) @paramter_list 
   (function_body) @body) 
@func)
``` 

( @fwcd )