### PR TITLE
fix: add type params to typealias

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -184,6 +184,7 @@ module.exports = grammar({
       optional($.modifiers),
       "typealias",
       alias($.simple_identifier, $.type_identifier),
+      optional($.type_parameters),
       "=",
       $._type
     ),
@@ -1172,7 +1173,7 @@ module.exports = grammar({
       $._backtick_identifier,
     ),
 
-    _alpha_identifier: $ => /[a-zA-Z_][a-zA-Z_0-9]*/,
+    _alpha_identifier: $ => /[\p{L}_][\p{L}\p{Nd}_]*/,
 
     _backtick_identifier: $ => /`[^\r\n`]+`/,
 

--- a/grammar.js
+++ b/grammar.js
@@ -1173,7 +1173,7 @@ module.exports = grammar({
       $._backtick_identifier,
     ),
 
-    _alpha_identifier: $ => /[\p{L}_][\p{L}\p{Nd}_]*/,
+    _alpha_identifier: $ => /[a-zA-Z_][a-zA-Z_0-9]*/,
 
     _backtick_identifier: $ => /`[^\r\n`]+`/,
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -268,6 +268,18 @@
           "value": "type_identifier"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_parameters"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "="
         },
@@ -5971,7 +5983,7 @@
     },
     "_alpha_identifier": {
       "type": "PATTERN",
-      "value": "[a-zA-Z_][a-zA-Z_0-9]*"
+      "value": "[\\p{L}_][\\p{L}\\p{Nd}_]*"
     },
     "_backtick_identifier": {
       "type": "PATTERN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5983,7 +5983,7 @@
     },
     "_alpha_identifier": {
       "type": "PATTERN",
-      "value": "[\\p{L}_][\\p{L}\\p{Nd}_]*"
+      "value": "[a-zA-Z_][a-zA-Z_0-9]*"
     },
     "_backtick_identifier": {
       "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8111,6 +8111,10 @@
           "named": true
         },
         {
+          "type": "type_parameters",
+          "named": true
+        },
+        {
           "type": "user_type",
           "named": true
         }

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
+  const char **symbol_names;
+  const char **field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -255,3 +255,23 @@ a as Foo(x = "hi", y = "bar",)
         (value_argument
           (simple_identifier)
           (string_literal))))))
+(source_file (call_expression (as_expression (simple_identifier) (user_type (type_identifier))) (call_suffix (value_arguments (value_argument (simple_identifier) (line_string_literal)) (value_argument (simple_identifier) (line_string_literal)))))) 
+
+==================
+Type alias with type parameters 
+==================
+
+private typealias T<E> = Foo<E>
+
+---
+
+(source_file 
+  (type_alias 
+    (modifiers (visibility_modifier)) 
+    (type_identifier) 
+    (type_parameters (type_parameter (type_identifier)))  
+  (user_type 
+    (type_identifier) 
+    (type_arguments 
+      (type_projection 
+        (user_type (type_identifier)))))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -255,23 +255,26 @@ a as Foo(x = "hi", y = "bar",)
         (value_argument
           (simple_identifier)
           (string_literal))))))
-(source_file (call_expression (as_expression (simple_identifier) (user_type (type_identifier))) (call_suffix (value_arguments (value_argument (simple_identifier) (line_string_literal)) (value_argument (simple_identifier) (line_string_literal)))))) 
 
-==================
-Type alias with type parameters 
-==================
+================================================================================
+Type alias with type parameters
+================================================================================
 
 private typealias T<E> = Foo<E>
 
----
+--------------------------------------------------------------------------------
 
-(source_file 
-  (type_alias 
-    (modifiers (visibility_modifier)) 
-    (type_identifier) 
-    (type_parameters (type_parameter (type_identifier)))  
-  (user_type 
-    (type_identifier) 
-    (type_arguments 
-      (type_projection 
-        (user_type (type_identifier)))))))
+(source_file
+  (type_alias
+    (modifiers
+      (visibility_modifier))
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (user_type
+      (type_identifier)
+      (type_arguments
+        (type_projection
+          (user_type
+            (type_identifier)))))))


### PR DESCRIPTION
This PR allows type parameters to occur after a type alias, which is allowed according to the Kotlin grammar:
https://kotlinlang.org/docs/reference/grammar.html#typeParameters