### PR TITLE
allow type params before navigation suffix

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -84,13 +84,13 @@ module.exports = grammar({
     [$._postfix_unary_expression, $._expression],
 
     // ambiguity between generics and comparison operations (foo < b > c)
-    [$.call_expression, $.prefix_expression, $.comparison_expression],
-    [$.call_expression, $.range_expression, $.comparison_expression],
-    [$.call_expression, $.elvis_expression, $.comparison_expression],
-    [$.call_expression, $.check_expression, $.comparison_expression],
-    [$.call_expression, $.additive_expression, $.comparison_expression],
-    [$.call_expression, $.infix_expression, $.comparison_expression],
-    [$.call_expression, $.multiplicative_expression, $.comparison_expression],
+    [$.call_expression, $.navigation_expression, $.prefix_expression, $.comparison_expression],
+    [$.call_expression, $.navigation_expression, $.range_expression, $.comparison_expression],
+    [$.call_expression, $.navigation_expression, $.elvis_expression, $.comparison_expression],
+    [$.call_expression, $.navigation_expression, $.check_expression, $.comparison_expression],
+    [$.call_expression, $.navigation_expression, $.additive_expression, $.comparison_expression],
+    [$.call_expression, $.navigation_expression, $.infix_expression, $.comparison_expression],
+    [$.call_expression, $.navigation_expression, $.multiplicative_expression, $.comparison_expression],
     [$.type_arguments, $._comparison_operator],
 
     // ambiguity between prefix expressions and annotations before functions
@@ -113,6 +113,7 @@ module.exports = grammar({
 
     // ambiguity between parameter modifiers in anonymous functions
     [$.parameter_modifiers, $._type_modifier],
+
   ],
 
   externals: $ => [
@@ -673,6 +674,8 @@ module.exports = grammar({
     indexing_suffix: $ => seq("[", sep1($._expression, ","), "]"),
 
     navigation_suffix: $ => seq(
+      // this introduces ambiguities with 'less than' for comparisons
+      optional($.type_arguments),
       $._member_access_operator,
       choice(
         $.simple_identifier,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3317,6 +3317,18 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "_member_access_operator"
         },
@@ -6133,36 +6145,43 @@
     ],
     [
       "call_expression",
+      "navigation_expression",
       "prefix_expression",
       "comparison_expression"
     ],
     [
       "call_expression",
+      "navigation_expression",
       "range_expression",
       "comparison_expression"
     ],
     [
       "call_expression",
+      "navigation_expression",
       "elvis_expression",
       "comparison_expression"
     ],
     [
       "call_expression",
+      "navigation_expression",
       "check_expression",
       "comparison_expression"
     ],
     [
       "call_expression",
+      "navigation_expression",
       "additive_expression",
       "comparison_expression"
     ],
     [
       "call_expression",
+      "navigation_expression",
       "infix_expression",
       "comparison_expression"
     ],
     [
       "call_expression",
+      "navigation_expression",
       "multiplicative_expression",
       "comparison_expression"
     ],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5828,7 +5828,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
@@ -5837,6 +5837,10 @@
         },
         {
           "type": "simple_identifier",
+          "named": true
+        },
+        {
+          "type": "type_arguments",
           "named": true
         }
       ]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char * const *symbol_names;
-  const char * const *field_names;
+  const char **symbol_names;
+  const char **field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,16 +1,19 @@
-==================
+================================================================================
 Multiplication expression
-==================
+================================================================================
 
 45 * 3
 
----
+--------------------------------------------------------------------------------
 
-(source_file (multiplicative_expression (integer_literal) (integer_literal)))
+(source_file
+  (multiplicative_expression
+    (integer_literal)
+    (integer_literal)))
 
-==================
+================================================================================
 Safe Navigation
-==================
+================================================================================
 
 a?.bar()
 a? .bar()
@@ -19,7 +22,7 @@ a?
   .bar()
 a ? . bar()
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (call_expression
@@ -58,27 +61,34 @@ a ? . bar()
     (call_suffix
       (value_arguments))))
 
-==================
+================================================================================
 Function calls
-==================
+================================================================================
 
 print("Hello World!")
 sum(1, 2)
 
----
+--------------------------------------------------------------------------------
 
 (source_file
-  (call_expression (simple_identifier)
-    (call_suffix (value_arguments
-      (value_argument (line_string_literal)))))
-  (call_expression (simple_identifier)
-    (call_suffix (value_arguments
-      (value_argument (integer_literal))
-      (value_argument (integer_literal))))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (line_string_literal)))))
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal))
+        (value_argument
+          (integer_literal))))))
 
-==================
+================================================================================
 When expression
-==================
+================================================================================
 
 val x = 1
 val y = when(x){
@@ -86,30 +96,39 @@ val y = when(x){
         2 -> false
     }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
-    (variable_declaration (simple_identifier))
+    (variable_declaration
+      (simple_identifier))
     (integer_literal))
   (property_declaration
-    (variable_declaration (simple_identifier))
+    (variable_declaration
+      (simple_identifier))
     (when_expression
-      (when_subject (simple_identifier))
-      (when_entry (when_condition (integer_literal))
-        (control_structure_body (boolean_literal)))
-      (when_entry (when_condition (integer_literal))
-        (control_structure_body (boolean_literal))))))
+      (when_subject
+        (simple_identifier))
+      (when_entry
+        (when_condition
+          (integer_literal))
+        (control_structure_body
+          (boolean_literal)))
+      (when_entry
+        (when_condition
+          (integer_literal))
+        (control_structure_body
+          (boolean_literal))))))
 
-=================
+================================================================================
 When expression with type arguments
-================
+================================================================================
 
 when (this) {
     is DispatchedCoroutine<*> -> return null
 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (when_expression
@@ -125,13 +144,13 @@ when (this) {
       (control_structure_body
         (jump_expression)))))
 
-==================
+================================================================================
 Value declaration with receiver type
-==================
+================================================================================
 
 val MyDate.s: String get() = "hello"
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (property_declaration
@@ -145,66 +164,109 @@ val MyDate.s: String get() = "hello"
       (function_body
         (line_string_literal)))))
 
-==================
+================================================================================
 Expect as an expression
-==================
+================================================================================
 
 val x = expect(1)
 
----
+--------------------------------------------------------------------------------
+
 (source_file
   (property_declaration
-    (variable_declaration (simple_identifier))
-    (call_expression (simple_identifier)
-      (call_suffix (value_arguments (value_argument (integer_literal)))))))
+    (variable_declaration
+      (simple_identifier))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (integer_literal)))))))
 
-==================
+================================================================================
 Expect as a top-level expression
-==================
+================================================================================
 
 expect(1)
 
----
-(source_file
-  (call_expression (simple_identifier)
-    (call_suffix (value_arguments (value_argument (integer_literal))))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (call_expression
+    (simple_identifier)
+    (call_suffix
+      (value_arguments
+        (value_argument
+          (integer_literal))))))
+
+================================================================================
 Expect as a platform modifier
-==================
+================================================================================
 
 expect fun randomUUID(): String
 
----
+--------------------------------------------------------------------------------
+
 (source_file
   (function_declaration
-    (modifiers (platform_modifier))
+    (modifiers
+      (platform_modifier))
     (simple_identifier)
-    (user_type (type_identifier))))
+    (user_type
+      (type_identifier))))
 
-==================
+================================================================================
 Less than for generics
-==================
+================================================================================
 
 foo<Int>(1,2)
 foo<Int>(1)
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-  (call_expression (simple_identifier)
+  (call_expression
+    (simple_identifier)
     (call_suffix
-      (type_arguments (type_projection (user_type (type_identifier))))
-      (value_arguments (value_argument (integer_literal))
-                       (value_argument (integer_literal)))))
-  (call_expression (simple_identifier)
+      (type_arguments
+        (type_projection
+          (user_type
+            (type_identifier))))
+      (value_arguments
+        (value_argument
+          (integer_literal))
+        (value_argument
+          (integer_literal)))))
+  (call_expression
+    (simple_identifier)
     (call_suffix
-      (type_arguments (type_projection (user_type (type_identifier))))
-      (value_arguments (value_argument (integer_literal))))))
+      (type_arguments
+        (type_projection
+          (user_type
+            (type_identifier))))
+      (value_arguments
+        (value_argument
+          (integer_literal))))))
 
+================================================================================
+Less than for reference
+================================================================================
 
-==================
+foo<*>::bar
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (navigation_expression
+    (simple_identifier)
+    (navigation_suffix
+      (type_arguments
+        (type_projection))
+      (simple_identifier))))
+
+================================================================================
 Less than for comparison
-==================
+================================================================================
 
 val x = a<b
 val y = a>b
@@ -213,34 +275,60 @@ val z = a<b>c
 val w = a<b>(c)
 val a = a<2>(3)
 
----
-(source_file
-  (property_declaration (variable_declaration (simple_identifier))
-     (comparison_expression (simple_identifier) (simple_identifier)))
-  (property_declaration (variable_declaration (simple_identifier))
-     (comparison_expression (simple_identifier) (simple_identifier)))
-  (property_declaration (variable_declaration (simple_identifier))
-     (comparison_expression
-        (comparison_expression (simple_identifier) (simple_identifier))
-        (simple_identifier)))
-  (comment)
-  (property_declaration (variable_declaration (simple_identifier))
-    (call_expression (simple_identifier)
-       (call_suffix
-         (type_arguments (type_projection (user_type (type_identifier))))
-       (value_arguments (value_argument (simple_identifier))))))
-  (property_declaration (variable_declaration (simple_identifier))
-      (comparison_expression
-         (comparison_expression (simple_identifier) (integer_literal))
-         (parenthesized_expression (integer_literal)))))
+--------------------------------------------------------------------------------
 
-==================
+(source_file
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (comparison_expression
+      (simple_identifier)
+      (simple_identifier)))
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (comparison_expression
+      (simple_identifier)
+      (simple_identifier)))
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (comparison_expression
+      (comparison_expression
+        (simple_identifier)
+        (simple_identifier))
+      (simple_identifier)))
+  (comment)
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (call_expression
+      (simple_identifier)
+      (call_suffix
+        (type_arguments
+          (type_projection
+            (user_type
+              (type_identifier))))
+        (value_arguments
+          (value_argument
+            (simple_identifier))))))
+  (property_declaration
+    (variable_declaration
+      (simple_identifier))
+    (comparison_expression
+      (comparison_expression
+        (simple_identifier)
+        (integer_literal))
+      (parenthesized_expression
+        (integer_literal)))))
+
+================================================================================
 Lambda Expressions
-==================
+================================================================================
 
 foo.forEach { (index, value) -> 2 }
 
----
+--------------------------------------------------------------------------------
 
 (source_file
   (call_expression
@@ -260,16 +348,16 @@ foo.forEach { (index, value) -> 2 }
           (statements
             (integer_literal)))))))
 
-==================
+================================================================================
 Multiple Statements on a Single Line
-==================
+================================================================================
 
 fun main() { val temp = b.y; b.y = b.z; b.z = temp }
 
 when (dir) {
   1 -> { val temp = b.y; b.y = b.z; b.z = temp }
 }
----
+--------------------------------------------------------------------------------
 
 (source_file
   (function_declaration


### PR DESCRIPTION
In my pursuits running the Kotlin parser on many open-source repos, I've noticed that a very common we cannot parse is expressions of the form `Foo<*>::bar`. It seems that this is an example of suffixing an expression with type parameters, and then doing a navigation suffix.

Unfortunately, it seems that naively writing the grammar with type parameters after arbitrary expressions is a surefire way to break comparison expressions. I decided to follow the same form as `call_suffix`, and instead allow type parameters in only a particular suffix, that being navigation suffixes.

Now, it works. Our parse rate went up like a percent as a result.

Test plan: Automated tests.