### PR TITLE
feat: add not nullable types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -113,6 +113,11 @@ module.exports = grammar({
 
     // ambiguity between parameter modifiers in anonymous functions
     [$.parameter_modifiers, $._type_modifier],
+
+    // ambiguity between type modifiers before an @  
+    [$.type_modifiers],
+    // ambiguity between associating type modifiers
+    [$.not_nullable_type],
   ],
 
   externals: $ => [
@@ -466,13 +471,22 @@ module.exports = grammar({
         $.parenthesized_type,
         $.nullable_type,
         $._type_reference,
-        $.function_type
+        $.function_type,
+        $.not_nullable_type
       )
     ),
 
-    _type_reference: $ => choice(
+    _type_reference: $ => prec.left(1, choice(
       $.user_type,
       "dynamic"
+    )),
+
+    not_nullable_type: $ => seq(
+      optional($.type_modifiers),
+      choice($.user_type, $.parenthesized_user_type),
+      '&',
+      optional($.type_modifiers),
+      choice($.user_type, $.parenthesized_user_type),
     ),
 
     nullable_type: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2177,21 +2177,88 @@
             {
               "type": "SYMBOL",
               "name": "function_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "not_nullable_type"
             }
           ]
         }
       ]
     },
     "_type_reference": {
-      "type": "CHOICE",
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "user_type"
+          },
+          {
+            "type": "STRING",
+            "value": "dynamic"
+          }
+        ]
+      }
+    },
+    "not_nullable_type": {
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "user_type"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_modifiers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "user_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parenthesized_user_type"
+            }
+          ]
         },
         {
           "type": "STRING",
-          "value": "dynamic"
+          "value": "&"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_modifiers"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "user_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "parenthesized_user_type"
+            }
+          ]
         }
       ]
     },
@@ -6127,6 +6194,12 @@
     [
       "parameter_modifiers",
       "_type_modifier"
+    ],
+    [
+      "type_modifiers"
+    ],
+    [
+      "not_nullable_type"
     ]
   ],
   "precedences": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -329,6 +329,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -544,6 +548,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -1027,6 +1035,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -1183,6 +1195,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -1473,6 +1489,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -3907,6 +3927,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -4019,6 +4043,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -4055,6 +4083,10 @@
       "types": [
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -4098,6 +4130,10 @@
         },
         {
           "type": "modifiers",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -5689,6 +5725,29 @@
     }
   },
   {
+    "type": "not_nullable_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "parenthesized_user_type",
+          "named": true
+        },
+        {
+          "type": "type_modifiers",
+          "named": true
+        },
+        {
+          "type": "user_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "nullable_type",
     "named": true,
     "fields": {},
@@ -5781,6 +5840,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -5837,6 +5900,10 @@
       "types": [
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -6043,6 +6110,10 @@
       "types": [
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -7373,6 +7444,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -8095,6 +8170,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -8150,6 +8229,10 @@
         },
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -8220,6 +8303,10 @@
       "types": [
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -8300,6 +8387,10 @@
           "named": true
         },
         {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -8347,6 +8438,10 @@
       "types": [
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -8611,6 +8706,10 @@
       "types": [
         {
           "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
           "named": true
         },
         {
@@ -9247,6 +9346,10 @@
   },
   {
     "type": "%=",
+    "named": false
+  },
+  {
+    "type": "&",
     "named": false
   },
   {

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -278,3 +278,41 @@ private typealias T<E> = Foo<E>
         (type_projection
           (user_type
             (type_identifier)))))))
+
+================================================================================
+Ampersand type
+================================================================================
+
+a as T & F
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (as_expression
+    (simple_identifier)
+    (not_nullable_type
+      (user_type
+        (type_identifier))
+      (user_type
+        (type_identifier)))))
+
+================================================================================
+Ampersand type with modifiers
+================================================================================
+
+a as @Foo T & F
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (as_expression
+    (simple_identifier)
+    (type_modifiers
+      (annotation
+        (user_type
+          (type_identifier))))
+    (not_nullable_type
+      (user_type
+        (type_identifier))
+      (user_type
+        (type_identifier)))))


### PR DESCRIPTION
This PR adds in "not nullable types", which to my understanding are types that look like `T1 & T2`.

https://kotlinlang.org/docs/reference/grammar.html#definitelyNonNullableType

Our parse rate goes from 98.366% to 98.372% with this.