### PR TITLE
fix: properly supported nested comments

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -210,11 +210,11 @@ bool scan_multiline_comment(TSLexer *lexer) {
         if (after_star) {
           after_star = false;
           nesting_depth--;
-          // if (nesting_depth == 0) {
+          if (nesting_depth == 0) {
             lexer->result_symbol = MULTILINE_COMMENT;
             mark_end(lexer);
             return true;
-          // }
+          }
         } else {
           after_star = false;
           if (lexer->lookahead == '*') {

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -4,8 +4,13 @@ Comments
 
 1 + 2
 // 1 + 2
-/*
-/* Hello world */
+/* very
+  /* nested
+     /* comment */
+  goes
+  */ 
+  here
+*/
 // "strings are cool too"
 /* even """multiline strings""" */
 


### PR DESCRIPTION
It turns out the original comment test case we were using was incorrect, because it assumed you could have unbalanced multiline comments nested in each other. I tried it out in the Kotlin playground and, as it turns out, you can't. They must be balanced. So I uncommented the code in the scanner that enforces that behavior, and changed the test.