### PR TITLE
Add missing tree-sitter section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,11 @@
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.20.7"
-  }
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.kotlin",
+      "file-types": ["kt"]
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "tree-sitter": [
     {
       "scope": "source.kotlin",
-      "file-types": ["kt"]
+      "file-types": ["kt", "kts"]
     }
   ]
 }


### PR DESCRIPTION
This section is necessary for using the grammar in tools like tree-sitter-cli, tree-sitter-graph, etc.

Someone has found this issue and made a PR #56 , but unfortunately wrote a wrong scope. This PR handled it correctly, thus you can merge this one and close #56 .