### PR TITLE
Build WASM binary in normal build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      EMSCRIPTEN_VERSION: '2.0.17'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
           node-version: '18'
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v12
+        with:
+          version: ${{ env.EMSCRIPTEN_VERSION }}
       - name: Install dependencies
         run: npm install
       - name: Generate parser

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,13 @@ jobs:
           test -z "$diff"
       - name: Run tests
         run: npm test
+      - name: Build WASM binary
+        run: npm run build-wasm
+      - name: Upload WASM binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: tree-sitter-kotlin.wasm
+          path: ./tree-sitter-kotlin.wasm
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/deploy-to-github.yml
+++ b/.github/workflows/deploy-to-github.yml
@@ -7,12 +7,18 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      EMSCRIPTEN_VERSION: '2.0.17'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
           node-version: '18'
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v12
+        with:
+          version: ${{ env.EMSCRIPTEN_VERSION }}
       - name: Install dependencies
         run: npm install
       - name: Compile grammar


### PR DESCRIPTION
This applies the suggestion from https://github.com/fwcd/tree-sitter-kotlin/issues/98#issuecomment-1743758082 and uses emscripten 2.0.17 to generate a WASM binary. Additionally, the binary is now built and exported as part of the standard CI workflow.