### PR TITLE
fix: improve jumps and class qualifiers

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4169,17 +4169,55 @@
       ]
     },
     "this_expression": {
-      "type": "STRING",
-      "value": "this"
-    },
-    "super_expression": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
           "type": "STRING",
-          "value": "super"
+          "value": "this"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_this_at"
         }
       ]
+    },
+    "super_expression": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "super"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "super"
+              },
+              {
+                "type": "STRING",
+                "value": "<"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_type"
+              },
+              {
+                "type": "STRING",
+                "value": ">"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_super_at"
+          }
+        ]
+      }
     },
     "if_expression": {
       "type": "PREC_RIGHT",
@@ -5449,8 +5487,13 @@
           "value": "return@"
         },
         {
-          "type": "SYMBOL",
-          "name": "_lexical_identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_lexical_identifier"
+          },
+          "named": true,
+          "value": "label"
         }
       ]
     },
@@ -5462,8 +5505,13 @@
           "value": "continue@"
         },
         {
-          "type": "SYMBOL",
-          "name": "_lexical_identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_lexical_identifier"
+          },
+          "named": true,
+          "value": "label"
         }
       ]
     },
@@ -5475,8 +5523,13 @@
           "value": "break@"
         },
         {
-          "type": "SYMBOL",
-          "name": "_lexical_identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_lexical_identifier"
+          },
+          "named": true,
+          "value": "label"
         }
       ]
     },
@@ -5488,21 +5541,73 @@
           "value": "this@"
         },
         {
-          "type": "SYMBOL",
-          "name": "_lexical_identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_lexical_identifier"
+          },
+          "named": true,
+          "value": "type_identifier"
         }
       ]
     },
     "_super_at": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "super@"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "super@"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_lexical_identifier"
+              },
+              "named": true,
+              "value": "type_identifier"
+            }
+          ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_lexical_identifier"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "super"
+            },
+            {
+              "type": "STRING",
+              "value": "<"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_type"
+            },
+            {
+              "type": "STRING",
+              "value": ">"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "@"
+              }
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_lexical_identifier"
+              },
+              "named": true,
+              "value": "type_identifier"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4936,7 +4936,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
@@ -5024,6 +5024,10 @@
           "named": true
         },
         {
+          "type": "label",
+          "named": true
+        },
+        {
           "type": "lambda_literal",
           "named": true
         },
@@ -5097,6 +5101,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "label",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "lambda_literal",
@@ -7822,12 +7831,56 @@
   {
     "type": "super_expression",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "function_type",
+          "named": true
+        },
+        {
+          "type": "not_nullable_type",
+          "named": true
+        },
+        {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
+          "type": "parenthesized_type",
+          "named": true
+        },
+        {
+          "type": "type_identifier",
+          "named": true
+        },
+        {
+          "type": "type_modifiers",
+          "named": true
+        },
+        {
+          "type": "user_type",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "this_expression",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "type_identifier",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "try_expression",
@@ -9370,10 +9423,6 @@
   {
     "type": "is",
     "named": false
-  },
-  {
-    "type": "label",
-    "named": true
   },
   {
     "type": "lateinit",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -213,7 +213,8 @@ expect fun randomUUID(): String
       (platform_modifier))
     (simple_identifier)
     (function_value_parameters)
-    (user_type (type_identifier))))
+    (user_type
+      (type_identifier))))
 
 ================================================================================
 Less than for generics
@@ -464,3 +465,74 @@ val comments = """ // and here """
     (variable_declaration
       (simple_identifier))
     (string_literal)))
+
+================================================================================
+Qualified this/super expressions
+================================================================================
+
+class Square() : Rectangle(), Polygon {
+    override fun draw() {
+        this@Square.draw()
+        super@Square.draw()
+        super<Polygon>.draw()
+        super<Rectangle>@Square.draw()
+    }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (primary_constructor)
+    (delegation_specifier
+      (constructor_invocation
+        (user_type
+          (type_identifier))
+        (value_arguments)))
+    (delegation_specifier
+      (user_type
+        (type_identifier)))
+    (class_body
+      (function_declaration
+        (modifiers
+          (member_modifier))
+        (simple_identifier)
+        (function_value_parameters)
+        (function_body
+          (statements
+            (call_expression
+              (navigation_expression
+                (this_expression
+                  (type_identifier))
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments)))
+            (call_expression
+              (navigation_expression
+                (super_expression
+                  (type_identifier))
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments)))
+            (call_expression
+              (navigation_expression
+                (super_expression
+                  (user_type
+                    (type_identifier)))
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments)))
+            (call_expression
+              (navigation_expression
+                (super_expression
+                  (user_type
+                    (type_identifier))
+                  (type_identifier))
+                (navigation_suffix
+                  (simple_identifier)))
+              (call_suffix
+                (value_arguments)))))))))


### PR DESCRIPTION
Upon reviewing nvim-treesitter/nvim-treesitter#5527 I noticed that (a) the jump expression labels are anonymous nodes and (b) the `_this_at` and `_super_at` rules are unused. This change makes it easier to capture the labels and classes and ensures that qualified calls are parsed as expected. I wanted to use `token.immediate("@")` in all of the `*_at` rules but the `label` rule would take precedence (even after editing it and raising the other rules' precedence) so I had to compromise.