### PR TITLE
Add field names

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -230,8 +230,8 @@ module.exports = grammar({
     )),
 
     primary_constructor: $ => seq(
-      optional(seq(optional($.modifiers), "constructor")),
-      $._class_parameters
+      optional(seq(optional(field('modifiers', $.modifiers)), "constructor")),
+      field('parameters', $._class_parameters)
     ),
 
     class_body: $ => seq("{", optional($._class_member_declarations), "}"),
@@ -423,11 +423,11 @@ module.exports = grammar({
     )),
 
     secondary_constructor: $ => seq(
-      optional($.modifiers),
+      optional(field('modifiers', $.modifiers)),
       "constructor",
-      $.function_value_parameters,
-      optional(seq(":", $.constructor_delegation_call)),
-      optional($._block)
+      field('parameters', $.function_value_parameters),
+      optional(seq(":", field('delegation', $.constructor_delegation_call))),
+      optional(field('body', $._block))
     ),
 
     constructor_delegation_call: $ => seq(choice("this", "super"), $.value_arguments),

--- a/grammar.js
+++ b/grammar.js
@@ -415,11 +415,11 @@ module.exports = grammar({
     parameter: $ => seq($.simple_identifier, ":", $._type),
 
     object_declaration: $ => prec.right(seq(
-      optional($.modifiers),
+      optional(field('modifiers', $.modifiers)),
       "object",
-      alias($.simple_identifier, $.type_identifier),
-      optional(seq(":", $._delegation_specifiers)),
-      optional($.class_body)
+      field('name', alias($.simple_identifier, $.type_identifier)),
+      optional(seq(":", field('delegation_specifiers', $._delegation_specifiers))),
+      optional(field('body', $.class_body))
     )),
 
     secondary_constructor: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -796,9 +796,9 @@ module.exports = grammar({
     anonymous_function: $ => prec.right(seq(
       "fun",
       optional(seq(sep1($._simple_user_type, "."), ".")), // TODO
-      $.function_value_parameters,
-      optional(seq(":", $._type)),
-      optional($.function_body)
+      field('parameters', $.function_value_parameters),
+      optional(seq(":", field('return_type', $._type))),
+      optional(field('body', $.function_body))
     )),
 
     _function_literal: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -775,8 +775,8 @@ module.exports = grammar({
 
     lambda_literal: $ => prec(PREC.LAMBDA_LITERAL, seq(
       "{",
-      optional(seq(optional($.lambda_parameters), "->")),
-      optional($.statements),
+      optional(seq(optional(field('parameters', $.lambda_parameters)), "->")),
+      optional(field('body', $.statements)),
       "}"
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -308,7 +308,7 @@ module.exports = grammar({
       $.secondary_constructor
     ),
 
-    anonymous_initializer: $ => seq("init", $._block),
+    anonymous_initializer: $ => seq("init", field('body', $._block)),
 
     companion_object: $ => seq(
       optional($.modifiers),

--- a/grammar.js
+++ b/grammar.js
@@ -570,27 +570,30 @@ module.exports = grammar({
       "for",
       "(",
       repeat($.annotation),
-      choice($.variable_declaration, $.multi_variable_declaration),
+      choice(
+        field('variable', $.variable_declaration),
+        field('variables', $.multi_variable_declaration)
+      ),
       "in",
-      $._expression,
+      field('value', $._expression),
       ")",
-      optional($.control_structure_body)
+      optional(field('body', $.control_structure_body))
     )),
 
     while_statement: $ => seq(
       "while",
       "(",
-      $._expression,
+      field('condition', $._expression),
       ")",
-      choice(";", $.control_structure_body)
+      choice(";", field('body', $.control_structure_body))
     ),
 
     do_while_statement: $ => prec.right(seq(
       "do",
-      optional($.control_structure_body),
+      optional(field('body', $.control_structure_body)),
       "while",
       "(",
-      $._expression,
+      field('condition', $._expression),
       ")",
     )),
 
@@ -825,15 +828,15 @@ module.exports = grammar({
 
     if_expression: $ => prec.right(seq(
       "if",
-      "(", $._expression, ")",
+      "(", field('condition', $._expression), ")",
       choice(
-        $.control_structure_body,
+        field('consequence', $.control_structure_body),
         ";",
         seq(
-          optional($.control_structure_body),
+          optional(field('consequence', $.control_structure_body)),
           optional(";"),
           "else",
-          choice($.control_structure_body, ";")
+          choice(field('alternative', $.control_structure_body), ";")
         )
       )
     )),
@@ -852,19 +855,19 @@ module.exports = grammar({
 
     when_expression: $ => seq(
       "when",
-      optional($.when_subject),
+      optional(field('subject', $.when_subject)),
       "{",
-      repeat($.when_entry),
+      repeat(field('entry', $.when_entry)),
       "}"
     ),
 
     when_entry: $ => seq(
       choice(
-        seq($.when_condition, repeat(seq(",", $.when_condition))),
+        seq(field('condition', $.when_condition), repeat(seq(",", field('condition', $.when_condition)))),
         "else"
       ),
       "->",
-      $.control_structure_body,
+      field('body', $.control_structure_body),
       optional($._semi)
     ),
 
@@ -880,9 +883,9 @@ module.exports = grammar({
 
     try_expression: $ => seq(
       "try",
-      $._block,
+      field('body', $._block),
       choice(
-        seq(repeat1($.catch_block), optional($.finally_block)),
+        seq(repeat1(field('catch', $.catch_block)), optional(field('finally', $.finally_block))),
         $.finally_block
       )
     ),
@@ -895,10 +898,10 @@ module.exports = grammar({
       ":",
       $._type,
       ")",
-      $._block,
+      field('body', $._block),
     ),
 
-    finally_block: $ => seq("finally", $._block),
+    finally_block: $ => seq("finally", field('body', $._block)),
 
     jump_expression: $ => choice(
       prec.right(PREC.RETURN_OR_THROW, seq("throw", $._expression)),

--- a/grammar.js
+++ b/grammar.js
@@ -342,15 +342,15 @@ module.exports = grammar({
     ),
 
     function_declaration: $ => prec.right(seq( // TODO
-      optional($.modifiers),
+      optional(field('modifiers', $.modifiers)),
       "fun",
-      optional($.type_parameters),
-      optional(seq($._receiver_type, optional('.'))),
-      $.simple_identifier,
-      $.function_value_parameters,
-      optional(seq(":", $._type)),
-      optional($.type_constraints),
-      optional($.function_body)
+      optional(field('type_parameters', $.type_parameters)),
+      optional(seq(field('receiver', $._receiver_type), optional('.'))),
+      field('name', $.simple_identifier),
+      field('parameters', $.function_value_parameters),
+      optional(seq(":", field('return_type', $._type))),
+      optional(field('constraints', $.type_constraints)),
+      optional(field('body', $.function_body))
     )),
 
     function_body: $ => choice($._block, seq("=", $._expression)),

--- a/grammar.js
+++ b/grammar.js
@@ -208,24 +208,24 @@ module.exports = grammar({
 
     class_declaration: $ => prec.right(choice(
       seq(
-        optional($.modifiers),
-        choice("class", "interface"),
-        alias($.simple_identifier, $.type_identifier),
-        optional($.type_parameters),
-        optional($.primary_constructor),
-        optional(seq(":", $._delegation_specifiers)),
-        optional($.type_constraints),
-        optional($.class_body)
+        optional(field('modifiers', $.modifiers)),
+        field('kind', choice("class", "interface")),
+        field('name', alias($.simple_identifier, $.type_identifier)),
+        optional(field('type_parameters', $.type_parameters)),
+        optional(field('primary_constructor', $.primary_constructor)),
+        optional(seq(":", field('delegation_specifiers', $._delegation_specifiers))),
+        optional(field('constraints', $.type_constraints)),
+        optional(field('body', $.class_body))
       ),
       seq(
-        optional($.modifiers),
-        "enum", "class",
-        alias($.simple_identifier, $.type_identifier),
-        optional($.type_parameters),
-        optional($.primary_constructor),
-        optional(seq(":", $._delegation_specifiers)),
-        optional($.type_constraints),
-        optional($.enum_class_body)
+        optional(field('modifiers', $.modifiers)),
+        field('kind', "enum"), "class",
+        field('name', alias($.simple_identifier, $.type_identifier)),
+        optional(field('type_parameters', $.type_parameters)),
+        optional(field('primary_constructor', $.primary_constructor)),
+        optional(seq(":", field('delegation_specifiers', $._delegation_specifiers))),
+        optional(field('constraints', $.type_constraints)),
+        optional(field('body', $.enum_class_body))
       )
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -311,12 +311,12 @@ module.exports = grammar({
     anonymous_initializer: $ => seq("init", field('body', $._block)),
 
     companion_object: $ => seq(
-      optional($.modifiers),
+      optional(field('modifiers', $.modifiers)),
       "companion",
       "object",
-      optional(alias($.simple_identifier, $.type_identifier)),
-      optional(seq(":", $._delegation_specifiers)),
-      optional($.class_body)
+      optional(field('name', alias($.simple_identifier, $.type_identifier))),
+      optional(seq(":", field('delegation_specifiers', $._delegation_specifiers))),
+      optional(field('body', $.class_body))
     ),
 
     function_value_parameters: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -177,12 +177,12 @@ module.exports = grammar({
     top_level_object: $ => seq($._declaration, optional($._semi)),
 
     type_alias: $ => seq(
-      optional($.modifiers),
+      optional(field('modifiers', $.modifiers)),
       "typealias",
-      alias($.simple_identifier, $.type_identifier),
-      optional($.type_parameters),
+      field('name', alias($.simple_identifier, $.type_identifier)),
+      optional(field('type_parameters', $.type_parameters)),
       "=",
-      $._type
+      field('type', $._type)
     ),
 
     _declaration: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -362,21 +362,21 @@ module.exports = grammar({
     )),
 
     property_declaration: $ => prec.right(seq(
-      optional($.modifiers),
-      choice("val", "var"),
-      optional($.type_parameters),
-      optional(seq($._receiver_type, optional('.'))),
-      choice($.variable_declaration, $.multi_variable_declaration),
-      optional($.type_constraints),
+      optional(field('modifiers', $.modifiers)),
+      field('kind', choice("val", "var")),
+      optional(field('type_parameters', $.type_parameters)),
+      optional(seq(field('receiver', $._receiver_type), optional('.'))),
+      choice(field('variable', $.variable_declaration), field('variables', $.multi_variable_declaration)),
+      optional(field('constraints', $.type_constraints)),
       optional(choice(
-        seq("=", $._expression),
-        $.property_delegate
+        seq("=", field('expression', $._expression)),
+        field('delegate', $.property_delegate)
       )),
       optional(';'),
       choice(
         // TODO: Getter-setter combinations
-        optional($.getter),
-        optional($.setter)
+        optional(field('getter', $.getter)),
+        optional(field('setter', $.setter))
       )
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -808,8 +808,8 @@ module.exports = grammar({
 
     object_literal: $ => seq(
       "object",
-      optional(seq(":", $._delegation_specifiers)),
-      $.class_body
+      optional(seq(":", field('delegation_specifiers', $._delegation_specifiers))),
+      field('body', $.class_body)
     ),
 
     this_expression: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -635,8 +635,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "modifiers"
+                      "type": "FIELD",
+                      "name": "modifiers",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "modifiers"
+                      }
                     },
                     {
                       "type": "BLANK"
@@ -655,8 +659,12 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_class_parameters"
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_class_parameters"
+          }
         }
       ]
     },
@@ -2102,8 +2110,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "modifiers"
+              "type": "FIELD",
+              "name": "modifiers",
+              "content": {
+                "type": "SYMBOL",
+                "name": "modifiers"
+              }
             },
             {
               "type": "BLANK"
@@ -2115,8 +2127,12 @@
           "value": "constructor"
         },
         {
-          "type": "SYMBOL",
-          "name": "function_value_parameters"
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "SYMBOL",
+            "name": "function_value_parameters"
+          }
         },
         {
           "type": "CHOICE",
@@ -2129,8 +2145,12 @@
                   "value": ":"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "constructor_delegation_call"
+                  "type": "FIELD",
+                  "name": "delegation",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "constructor_delegation_call"
+                  }
                 }
               ]
             },
@@ -2143,8 +2163,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_block"
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block"
+              }
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1535,8 +1535,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "modifiers"
+                "type": "FIELD",
+                "name": "modifiers",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "modifiers"
+                }
               },
               {
                 "type": "BLANK"
@@ -1544,24 +1548,32 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "val"
-              },
-              {
-                "type": "STRING",
-                "value": "var"
-              }
-            ]
+            "type": "FIELD",
+            "name": "kind",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "val"
+                },
+                {
+                  "type": "STRING",
+                  "value": "var"
+                }
+              ]
+            }
           },
           {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "type_parameters"
+                "type": "FIELD",
+                "name": "type_parameters",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "type_parameters"
+                }
               },
               {
                 "type": "BLANK"
@@ -1575,8 +1587,12 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "_receiver_type"
+                    "type": "FIELD",
+                    "name": "receiver",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_receiver_type"
+                    }
                   },
                   {
                     "type": "CHOICE",
@@ -1601,12 +1617,20 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "variable_declaration"
+                "type": "FIELD",
+                "name": "variable",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "variable_declaration"
+                }
               },
               {
-                "type": "SYMBOL",
-                "name": "multi_variable_declaration"
+                "type": "FIELD",
+                "name": "variables",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "multi_variable_declaration"
+                }
               }
             ]
           },
@@ -1614,8 +1638,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "type_constraints"
+                "type": "FIELD",
+                "name": "constraints",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "type_constraints"
+                }
               },
               {
                 "type": "BLANK"
@@ -1636,14 +1664,22 @@
                         "value": "="
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "_expression"
+                        "type": "FIELD",
+                        "name": "expression",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_expression"
+                        }
                       }
                     ]
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "property_delegate"
+                    "type": "FIELD",
+                    "name": "delegate",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "property_delegate"
+                    }
                   }
                 ]
               },
@@ -1671,8 +1707,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "getter"
+                    "type": "FIELD",
+                    "name": "getter",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "getter"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -1683,8 +1723,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "setter"
+                    "type": "FIELD",
+                    "name": "setter",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "setter"
+                    }
                   },
                   {
                     "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2936,12 +2936,20 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "variable_declaration"
+                "type": "FIELD",
+                "name": "variable",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "variable_declaration"
+                }
               },
               {
-                "type": "SYMBOL",
-                "name": "multi_variable_declaration"
+                "type": "FIELD",
+                "name": "variables",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "multi_variable_declaration"
+                }
               }
             ]
           },
@@ -2950,8 +2958,12 @@
             "value": "in"
           },
           {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "FIELD",
+            "name": "value",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
           },
           {
             "type": "STRING",
@@ -2961,8 +2973,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "control_structure_body"
+                "type": "FIELD",
+                "name": "body",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "control_structure_body"
+                }
               },
               {
                 "type": "BLANK"
@@ -2984,8 +3000,12 @@
           "value": "("
         },
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
         },
         {
           "type": "STRING",
@@ -2999,8 +3019,12 @@
               "value": ";"
             },
             {
-              "type": "SYMBOL",
-              "name": "control_structure_body"
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "control_structure_body"
+              }
             }
           ]
         }
@@ -3020,8 +3044,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "control_structure_body"
+                "type": "FIELD",
+                "name": "body",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "control_structure_body"
+                }
               },
               {
                 "type": "BLANK"
@@ -3037,8 +3065,12 @@
             "value": "("
           },
           {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
           },
           {
             "type": "STRING",
@@ -4478,8 +4510,12 @@
             "value": "("
           },
           {
-            "type": "SYMBOL",
-            "name": "_expression"
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
           },
           {
             "type": "STRING",
@@ -4489,8 +4525,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "control_structure_body"
+                "type": "FIELD",
+                "name": "consequence",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "control_structure_body"
+                }
               },
               {
                 "type": "STRING",
@@ -4503,8 +4543,12 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "control_structure_body"
+                        "type": "FIELD",
+                        "name": "consequence",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "control_structure_body"
+                        }
                       },
                       {
                         "type": "BLANK"
@@ -4531,8 +4575,12 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "control_structure_body"
+                        "type": "FIELD",
+                        "name": "alternative",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "control_structure_body"
+                        }
                       },
                       {
                         "type": "STRING",
@@ -4607,8 +4655,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "when_subject"
+              "type": "FIELD",
+              "name": "subject",
+              "content": {
+                "type": "SYMBOL",
+                "name": "when_subject"
+              }
             },
             {
               "type": "BLANK"
@@ -4622,8 +4674,12 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "when_entry"
+            "type": "FIELD",
+            "name": "entry",
+            "content": {
+              "type": "SYMBOL",
+              "name": "when_entry"
+            }
           }
         },
         {
@@ -4642,8 +4698,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "when_condition"
+                  "type": "FIELD",
+                  "name": "condition",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "when_condition"
+                  }
                 },
                 {
                   "type": "REPEAT",
@@ -4655,8 +4715,12 @@
                         "value": ","
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "when_condition"
+                        "type": "FIELD",
+                        "name": "condition",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "when_condition"
+                        }
                       }
                     ]
                   }
@@ -4674,8 +4738,12 @@
           "value": "->"
         },
         {
-          "type": "SYMBOL",
-          "name": "control_structure_body"
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "control_structure_body"
+          }
         },
         {
           "type": "CHOICE",
@@ -4742,8 +4810,12 @@
           "value": "try"
         },
         {
-          "type": "SYMBOL",
-          "name": "_block"
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_block"
+          }
         },
         {
           "type": "CHOICE",
@@ -4754,16 +4826,24 @@
                 {
                   "type": "REPEAT1",
                   "content": {
-                    "type": "SYMBOL",
-                    "name": "catch_block"
+                    "type": "FIELD",
+                    "name": "catch",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "catch_block"
+                    }
                   }
                 },
                 {
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "finally_block"
+                      "type": "FIELD",
+                      "name": "finally",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "finally_block"
+                      }
                     },
                     {
                       "type": "BLANK"
@@ -4815,8 +4895,12 @@
           "value": ")"
         },
         {
-          "type": "SYMBOL",
-          "name": "_block"
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_block"
+          }
         }
       ]
     },
@@ -4828,8 +4912,12 @@
           "value": "finally"
         },
         {
-          "type": "SYMBOL",
-          "name": "_block"
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_block"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1128,8 +1128,12 @@
           "value": "init"
         },
         {
-          "type": "SYMBOL",
-          "name": "_block"
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_block"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4388,8 +4388,12 @@
                   "value": ":"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_delegation_specifiers"
+                  "type": "FIELD",
+                  "name": "delegation_specifiers",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_delegation_specifiers"
+                  }
                 }
               ]
             },
@@ -4399,8 +4403,12 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "class_body"
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "class_body"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -335,8 +335,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "modifiers"
+                    "type": "FIELD",
+                    "name": "modifiers",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "modifiers"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -344,33 +348,45 @@
                 ]
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "class"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "interface"
-                  }
-                ]
-              },
-              {
-                "type": "ALIAS",
+                "type": "FIELD",
+                "name": "kind",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "simple_identifier"
-                },
-                "named": true,
-                "value": "type_identifier"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "class"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "interface"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "name",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "simple_identifier"
+                  },
+                  "named": true,
+                  "value": "type_identifier"
+                }
               },
               {
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "type_parameters"
+                    "type": "FIELD",
+                    "name": "type_parameters",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "type_parameters"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -381,8 +397,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "primary_constructor"
+                    "type": "FIELD",
+                    "name": "primary_constructor",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "primary_constructor"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -400,8 +420,12 @@
                         "value": ":"
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "_delegation_specifiers"
+                        "type": "FIELD",
+                        "name": "delegation_specifiers",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_delegation_specifiers"
+                        }
                       }
                     ]
                   },
@@ -414,8 +438,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "type_constraints"
+                    "type": "FIELD",
+                    "name": "constraints",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "type_constraints"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -426,8 +454,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "class_body"
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "class_body"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -443,8 +475,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "modifiers"
+                    "type": "FIELD",
+                    "name": "modifiers",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "modifiers"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -452,28 +488,40 @@
                 ]
               },
               {
-                "type": "STRING",
-                "value": "enum"
+                "type": "FIELD",
+                "name": "kind",
+                "content": {
+                  "type": "STRING",
+                  "value": "enum"
+                }
               },
               {
                 "type": "STRING",
                 "value": "class"
               },
               {
-                "type": "ALIAS",
+                "type": "FIELD",
+                "name": "name",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "simple_identifier"
-                },
-                "named": true,
-                "value": "type_identifier"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "simple_identifier"
+                  },
+                  "named": true,
+                  "value": "type_identifier"
+                }
               },
               {
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "type_parameters"
+                    "type": "FIELD",
+                    "name": "type_parameters",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "type_parameters"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -484,8 +532,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "primary_constructor"
+                    "type": "FIELD",
+                    "name": "primary_constructor",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "primary_constructor"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -503,8 +555,12 @@
                         "value": ":"
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "_delegation_specifiers"
+                        "type": "FIELD",
+                        "name": "delegation_specifiers",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_delegation_specifiers"
+                        }
                       }
                     ]
                   },
@@ -517,8 +573,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "type_constraints"
+                    "type": "FIELD",
+                    "name": "constraints",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "type_constraints"
+                    }
                   },
                   {
                     "type": "BLANK"
@@ -529,8 +589,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "enum_class_body"
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "enum_class_body"
+                    }
                   },
                   {
                     "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4306,8 +4306,12 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "function_value_parameters"
+            "type": "FIELD",
+            "name": "parameters",
+            "content": {
+              "type": "SYMBOL",
+              "name": "function_value_parameters"
+            }
           },
           {
             "type": "CHOICE",
@@ -4320,8 +4324,12 @@
                     "value": ":"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_type"
+                    "type": "FIELD",
+                    "name": "return_type",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_type"
+                    }
                   }
                 ]
               },
@@ -4334,8 +4342,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "function_body"
+                "type": "FIELD",
+                "name": "body",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "function_body"
+                }
               },
               {
                 "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -246,8 +246,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "modifiers"
+              "type": "FIELD",
+              "name": "modifiers",
+              "content": {
+                "type": "SYMBOL",
+                "name": "modifiers"
+              }
             },
             {
               "type": "BLANK"
@@ -259,20 +263,28 @@
           "value": "typealias"
         },
         {
-          "type": "ALIAS",
+          "type": "FIELD",
+          "name": "name",
           "content": {
-            "type": "SYMBOL",
-            "name": "simple_identifier"
-          },
-          "named": true,
-          "value": "type_identifier"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "simple_identifier"
+            },
+            "named": true,
+            "value": "type_identifier"
+          }
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "type_parameters"
+              "type": "FIELD",
+              "name": "type_parameters",
+              "content": {
+                "type": "SYMBOL",
+                "name": "type_parameters"
+              }
             },
             {
               "type": "BLANK"
@@ -284,8 +296,12 @@
           "value": "="
         },
         {
-          "type": "SYMBOL",
-          "name": "_type"
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_type"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1144,8 +1144,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "modifiers"
+              "type": "FIELD",
+              "name": "modifiers",
+              "content": {
+                "type": "SYMBOL",
+                "name": "modifiers"
+              }
             },
             {
               "type": "BLANK"
@@ -1164,13 +1168,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
+              "type": "FIELD",
+              "name": "name",
               "content": {
-                "type": "SYMBOL",
-                "name": "simple_identifier"
-              },
-              "named": true,
-              "value": "type_identifier"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "simple_identifier"
+                },
+                "named": true,
+                "value": "type_identifier"
+              }
             },
             {
               "type": "BLANK"
@@ -1188,8 +1196,12 @@
                   "value": ":"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_delegation_specifiers"
+                  "type": "FIELD",
+                  "name": "delegation_specifiers",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_delegation_specifiers"
+                  }
                 }
               ]
             },
@@ -1202,8 +1214,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "class_body"
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "class_body"
+              }
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1264,8 +1264,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "modifiers"
+                "type": "FIELD",
+                "name": "modifiers",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "modifiers"
+                }
               },
               {
                 "type": "BLANK"
@@ -1280,8 +1284,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "type_parameters"
+                "type": "FIELD",
+                "name": "type_parameters",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "type_parameters"
+                }
               },
               {
                 "type": "BLANK"
@@ -1295,8 +1303,12 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "_receiver_type"
+                    "type": "FIELD",
+                    "name": "receiver",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_receiver_type"
+                    }
                   },
                   {
                     "type": "CHOICE",
@@ -1318,12 +1330,20 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "simple_identifier"
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "simple_identifier"
+            }
           },
           {
-            "type": "SYMBOL",
-            "name": "function_value_parameters"
+            "type": "FIELD",
+            "name": "parameters",
+            "content": {
+              "type": "SYMBOL",
+              "name": "function_value_parameters"
+            }
           },
           {
             "type": "CHOICE",
@@ -1336,8 +1356,12 @@
                     "value": ":"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_type"
+                    "type": "FIELD",
+                    "name": "return_type",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_type"
+                    }
                   }
                 ]
               },
@@ -1350,8 +1374,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "type_constraints"
+                "type": "FIELD",
+                "name": "constraints",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "type_constraints"
+                }
               },
               {
                 "type": "BLANK"
@@ -1362,8 +1390,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "function_body"
+                "type": "FIELD",
+                "name": "body",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "function_body"
+                }
               },
               {
                 "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1962,8 +1962,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "modifiers"
+                "type": "FIELD",
+                "name": "modifiers",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "modifiers"
+                }
               },
               {
                 "type": "BLANK"
@@ -1975,13 +1979,17 @@
             "value": "object"
           },
           {
-            "type": "ALIAS",
+            "type": "FIELD",
+            "name": "name",
             "content": {
-              "type": "SYMBOL",
-              "name": "simple_identifier"
-            },
-            "named": true,
-            "value": "type_identifier"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "simple_identifier"
+              },
+              "named": true,
+              "value": "type_identifier"
+            }
           },
           {
             "type": "CHOICE",
@@ -1994,8 +2002,12 @@
                     "value": ":"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_delegation_specifiers"
+                    "type": "FIELD",
+                    "name": "delegation_specifiers",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_delegation_specifiers"
+                    }
                   }
                 ]
               },
@@ -2008,8 +2020,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "class_body"
+                "type": "FIELD",
+                "name": "body",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "class_body"
+                }
               },
               {
                 "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4131,8 +4131,12 @@
                     "type": "CHOICE",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "lambda_parameters"
+                        "type": "FIELD",
+                        "name": "parameters",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "lambda_parameters"
+                        }
                       },
                       {
                         "type": "BLANK"
@@ -4154,8 +4158,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "statements"
+                "type": "FIELD",
+                "name": "body",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "statements"
+                }
               },
               {
                 "type": "BLANK"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5763,28 +5763,51 @@
   {
     "type": "object_declaration",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "class_body",
-          "named": true
-        },
-        {
-          "type": "delegation_specifier",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "class_body",
+            "named": true
+          }
+        ]
+      },
+      "delegation_specifiers": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "delegation_specifier",
+            "named": true
+          }
+        ]
+      },
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1170,44 +1170,103 @@
   {
     "type": "class_declaration",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "class_body",
-          "named": true
-        },
-        {
-          "type": "delegation_specifier",
-          "named": true
-        },
-        {
-          "type": "enum_class_body",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        },
-        {
-          "type": "primary_constructor",
-          "named": true
-        },
-        {
-          "type": "type_constraints",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
-          "named": true
-        },
-        {
-          "type": "type_parameters",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "class_body",
+            "named": true
+          },
+          {
+            "type": "enum_class_body",
+            "named": true
+          }
+        ]
+      },
+      "constraints": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_constraints",
+            "named": true
+          }
+        ]
+      },
+      "delegation_specifiers": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "delegation_specifier",
+            "named": true
+          }
+        ]
+      },
+      "kind": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "class",
+            "named": false
+          },
+          {
+            "type": "enum",
+            "named": false
+          },
+          {
+            "type": "interface",
+            "named": false
+          }
+        ]
+      },
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      },
+      "primary_constructor": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "primary_constructor",
+            "named": true
+          }
+        ]
+      },
+      "type_parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_parameters",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -266,16 +266,25 @@
   {
     "type": "anonymous_initializer",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "statements",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "statements",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1648,28 +1648,51 @@
   {
     "type": "companion_object",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "class_body",
-          "named": true
-        },
-        {
-          "type": "delegation_specifier",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "class_body",
+            "named": true
+          }
+        ]
+      },
+      "delegation_specifiers": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "delegation_specifier",
+            "named": true
+          }
+        ]
+      },
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -215,49 +215,72 @@
   {
     "type": "anonymous_function",
     "named": true,
-    "fields": {},
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "function_body",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "function_value_parameters",
+            "named": true
+          }
+        ]
+      },
+      "return_type": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "dynamic",
+            "named": false
+          },
+          {
+            "type": "function_type",
+            "named": true
+          },
+          {
+            "type": "not_nullable_type",
+            "named": true
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized_type",
+            "named": true
+          },
+          {
+            "type": "type_modifiers",
+            "named": true
+          },
+          {
+            "type": "user_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "function_body",
-          "named": true
-        },
-        {
-          "type": "function_type",
-          "named": true
-        },
-        {
-          "type": "function_value_parameters",
-          "named": true
-        },
-        {
-          "type": "not_nullable_type",
-          "named": true
-        },
-        {
-          "type": "nullable_type",
-          "named": true
-        },
-        {
-          "type": "parenthesized_type",
-          "named": true
-        },
         {
           "type": "type_arguments",
           "named": true
         },
         {
           "type": "type_identifier",
-          "named": true
-        },
-        {
-          "type": "type_modifiers",
-          "named": true
-        },
-        {
-          "type": "user_type",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6540,216 +6540,293 @@
   {
     "type": "property_declaration",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "getter",
-          "named": true
-        },
-        {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        },
-        {
-          "type": "multi_variable_declaration",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
-          "type": "nullable_type",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "parenthesized_type",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "property_delegate",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "setter",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
-          "named": true
-        },
-        {
-          "type": "type_constraints",
-          "named": true
-        },
-        {
-          "type": "type_modifiers",
-          "named": true
-        },
-        {
-          "type": "type_parameters",
-          "named": true
-        },
-        {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "user_type",
-          "named": true
-        },
-        {
-          "type": "variable_declaration",
-          "named": true
-        },
-        {
-          "type": "when_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "constraints": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_constraints",
+            "named": true
+          }
+        ]
+      },
+      "delegate": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "property_delegate",
+            "named": true
+          }
+        ]
+      },
+      "expression": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "additive_expression",
+            "named": true
+          },
+          {
+            "type": "anonymous_function",
+            "named": true
+          },
+          {
+            "type": "as_expression",
+            "named": true
+          },
+          {
+            "type": "bin_literal",
+            "named": true
+          },
+          {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "callable_reference",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "check_expression",
+            "named": true
+          },
+          {
+            "type": "collection_literal",
+            "named": true
+          },
+          {
+            "type": "comparison_expression",
+            "named": true
+          },
+          {
+            "type": "conjunction_expression",
+            "named": true
+          },
+          {
+            "type": "disjunction_expression",
+            "named": true
+          },
+          {
+            "type": "elvis_expression",
+            "named": true
+          },
+          {
+            "type": "equality_expression",
+            "named": true
+          },
+          {
+            "type": "hex_literal",
+            "named": true
+          },
+          {
+            "type": "if_expression",
+            "named": true
+          },
+          {
+            "type": "indexing_expression",
+            "named": true
+          },
+          {
+            "type": "infix_expression",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "jump_expression",
+            "named": true
+          },
+          {
+            "type": "lambda_literal",
+            "named": true
+          },
+          {
+            "type": "long_literal",
+            "named": true
+          },
+          {
+            "type": "multiplicative_expression",
+            "named": true
+          },
+          {
+            "type": "navigation_expression",
+            "named": true
+          },
+          {
+            "type": "null",
+            "named": false
+          },
+          {
+            "type": "object_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "postfix_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "range_expression",
+            "named": true
+          },
+          {
+            "type": "real_literal",
+            "named": true
+          },
+          {
+            "type": "simple_identifier",
+            "named": true
+          },
+          {
+            "type": "spread_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "super_expression",
+            "named": true
+          },
+          {
+            "type": "this_expression",
+            "named": true
+          },
+          {
+            "type": "try_expression",
+            "named": true
+          },
+          {
+            "type": "unsigned_literal",
+            "named": true
+          },
+          {
+            "type": "when_expression",
+            "named": true
+          }
+        ]
+      },
+      "getter": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "getter",
+            "named": true
+          }
+        ]
+      },
+      "kind": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "val",
+            "named": false
+          },
+          {
+            "type": "var",
+            "named": false
+          }
+        ]
+      },
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "receiver": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "dynamic",
+            "named": false
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized_type",
+            "named": true
+          },
+          {
+            "type": "type_modifiers",
+            "named": true
+          },
+          {
+            "type": "user_type",
+            "named": true
+          }
+        ]
+      },
+      "setter": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "setter",
+            "named": true
+          }
+        ]
+      },
+      "type_parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_parameters",
+            "named": true
+          }
+        ]
+      },
+      "variable": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "variable_declaration",
+            "named": true
+          }
+        ]
+      },
+      "variables": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "multi_variable_declaration",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -893,7 +893,26 @@
   {
     "type": "catch_block",
     "named": true,
-    "fields": {},
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "statements",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -920,10 +939,6 @@
         },
         {
           "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "statements",
           "named": true
         },
         {
@@ -2613,172 +2628,183 @@
   {
     "type": "do_while_statement",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "control_structure_body",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
-          "named": true
-        },
-        {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "when_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "control_structure_body",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "additive_expression",
+            "named": true
+          },
+          {
+            "type": "anonymous_function",
+            "named": true
+          },
+          {
+            "type": "as_expression",
+            "named": true
+          },
+          {
+            "type": "bin_literal",
+            "named": true
+          },
+          {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "callable_reference",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "check_expression",
+            "named": true
+          },
+          {
+            "type": "collection_literal",
+            "named": true
+          },
+          {
+            "type": "comparison_expression",
+            "named": true
+          },
+          {
+            "type": "conjunction_expression",
+            "named": true
+          },
+          {
+            "type": "disjunction_expression",
+            "named": true
+          },
+          {
+            "type": "elvis_expression",
+            "named": true
+          },
+          {
+            "type": "equality_expression",
+            "named": true
+          },
+          {
+            "type": "hex_literal",
+            "named": true
+          },
+          {
+            "type": "if_expression",
+            "named": true
+          },
+          {
+            "type": "indexing_expression",
+            "named": true
+          },
+          {
+            "type": "infix_expression",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "jump_expression",
+            "named": true
+          },
+          {
+            "type": "lambda_literal",
+            "named": true
+          },
+          {
+            "type": "long_literal",
+            "named": true
+          },
+          {
+            "type": "multiplicative_expression",
+            "named": true
+          },
+          {
+            "type": "navigation_expression",
+            "named": true
+          },
+          {
+            "type": "null",
+            "named": false
+          },
+          {
+            "type": "object_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "postfix_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "range_expression",
+            "named": true
+          },
+          {
+            "type": "real_literal",
+            "named": true
+          },
+          {
+            "type": "simple_identifier",
+            "named": true
+          },
+          {
+            "type": "spread_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "super_expression",
+            "named": true
+          },
+          {
+            "type": "this_expression",
+            "named": true
+          },
+          {
+            "type": "try_expression",
+            "named": true
+          },
+          {
+            "type": "unsigned_literal",
+            "named": true
+          },
+          {
+            "type": "when_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3394,196 +3420,234 @@
   {
     "type": "finally_block",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "statements",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "statements",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      }
     }
   },
   {
     "type": "for_statement",
     "named": true,
-    "fields": {},
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "control_structure_body",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "additive_expression",
+            "named": true
+          },
+          {
+            "type": "anonymous_function",
+            "named": true
+          },
+          {
+            "type": "as_expression",
+            "named": true
+          },
+          {
+            "type": "bin_literal",
+            "named": true
+          },
+          {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "callable_reference",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "check_expression",
+            "named": true
+          },
+          {
+            "type": "collection_literal",
+            "named": true
+          },
+          {
+            "type": "comparison_expression",
+            "named": true
+          },
+          {
+            "type": "conjunction_expression",
+            "named": true
+          },
+          {
+            "type": "disjunction_expression",
+            "named": true
+          },
+          {
+            "type": "elvis_expression",
+            "named": true
+          },
+          {
+            "type": "equality_expression",
+            "named": true
+          },
+          {
+            "type": "hex_literal",
+            "named": true
+          },
+          {
+            "type": "if_expression",
+            "named": true
+          },
+          {
+            "type": "indexing_expression",
+            "named": true
+          },
+          {
+            "type": "infix_expression",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "jump_expression",
+            "named": true
+          },
+          {
+            "type": "lambda_literal",
+            "named": true
+          },
+          {
+            "type": "long_literal",
+            "named": true
+          },
+          {
+            "type": "multiplicative_expression",
+            "named": true
+          },
+          {
+            "type": "navigation_expression",
+            "named": true
+          },
+          {
+            "type": "null",
+            "named": false
+          },
+          {
+            "type": "object_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "postfix_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "range_expression",
+            "named": true
+          },
+          {
+            "type": "real_literal",
+            "named": true
+          },
+          {
+            "type": "simple_identifier",
+            "named": true
+          },
+          {
+            "type": "spread_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "super_expression",
+            "named": true
+          },
+          {
+            "type": "this_expression",
+            "named": true
+          },
+          {
+            "type": "try_expression",
+            "named": true
+          },
+          {
+            "type": "unsigned_literal",
+            "named": true
+          },
+          {
+            "type": "when_expression",
+            "named": true
+          }
+        ]
+      },
+      "variable": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "variable_declaration",
+            "named": true
+          }
+        ]
+      },
+      "variables": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "multi_variable_declaration",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
           "type": "annotation",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "control_structure_body",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
-          "named": true
-        },
-        {
-          "type": "multi_variable_declaration",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
-          "named": true
-        },
-        {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "variable_declaration",
-          "named": true
-        },
-        {
-          "type": "when_expression",
           "named": true
         }
       ]
@@ -4213,172 +4277,193 @@
   {
     "type": "if_expression",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "control_structure_body",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
-          "named": true
-        },
-        {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "when_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "alternative": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "control_structure_body",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "additive_expression",
+            "named": true
+          },
+          {
+            "type": "anonymous_function",
+            "named": true
+          },
+          {
+            "type": "as_expression",
+            "named": true
+          },
+          {
+            "type": "bin_literal",
+            "named": true
+          },
+          {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "callable_reference",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "check_expression",
+            "named": true
+          },
+          {
+            "type": "collection_literal",
+            "named": true
+          },
+          {
+            "type": "comparison_expression",
+            "named": true
+          },
+          {
+            "type": "conjunction_expression",
+            "named": true
+          },
+          {
+            "type": "disjunction_expression",
+            "named": true
+          },
+          {
+            "type": "elvis_expression",
+            "named": true
+          },
+          {
+            "type": "equality_expression",
+            "named": true
+          },
+          {
+            "type": "hex_literal",
+            "named": true
+          },
+          {
+            "type": "if_expression",
+            "named": true
+          },
+          {
+            "type": "indexing_expression",
+            "named": true
+          },
+          {
+            "type": "infix_expression",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "jump_expression",
+            "named": true
+          },
+          {
+            "type": "lambda_literal",
+            "named": true
+          },
+          {
+            "type": "long_literal",
+            "named": true
+          },
+          {
+            "type": "multiplicative_expression",
+            "named": true
+          },
+          {
+            "type": "navigation_expression",
+            "named": true
+          },
+          {
+            "type": "null",
+            "named": false
+          },
+          {
+            "type": "object_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "postfix_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "range_expression",
+            "named": true
+          },
+          {
+            "type": "real_literal",
+            "named": true
+          },
+          {
+            "type": "simple_identifier",
+            "named": true
+          },
+          {
+            "type": "spread_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "super_expression",
+            "named": true
+          },
+          {
+            "type": "this_expression",
+            "named": true
+          },
+          {
+            "type": "try_expression",
+            "named": true
+          },
+          {
+            "type": "unsigned_literal",
+            "named": true
+          },
+          {
+            "type": "when_expression",
+            "named": true
+          }
+        ]
+      },
+      "consequence": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "control_structure_body",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -8230,21 +8315,52 @@
   {
     "type": "try_expression",
     "named": true,
-    "fields": {},
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "statements",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      },
+      "catch": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "catch_block",
+            "named": true
+          }
+        ]
+      },
+      "finally": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "finally_block",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
         {
-          "type": "catch_block",
-          "named": true
-        },
-        {
           "type": "finally_block",
-          "named": true
-        },
-        {
-          "type": "statements",
           "named": true
         }
       ]
@@ -9043,39 +9159,53 @@
   {
     "type": "when_entry",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "control_structure_body",
-          "named": true
-        },
-        {
-          "type": "when_condition",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "control_structure_body",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "when_condition",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
     "type": "when_expression",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "when_entry",
-          "named": true
-        },
-        {
-          "type": "when_subject",
-          "named": true
-        }
-      ]
+    "fields": {
+      "entry": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "when_entry",
+            "named": true
+          }
+        ]
+      },
+      "subject": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "when_subject",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -9256,172 +9386,183 @@
   {
     "type": "while_statement",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "anonymous_function",
-          "named": true
-        },
-        {
-          "type": "as_expression",
-          "named": true
-        },
-        {
-          "type": "bin_literal",
-          "named": true
-        },
-        {
-          "type": "boolean_literal",
-          "named": true
-        },
-        {
-          "type": "call_expression",
-          "named": true
-        },
-        {
-          "type": "callable_reference",
-          "named": true
-        },
-        {
-          "type": "character_literal",
-          "named": true
-        },
-        {
-          "type": "check_expression",
-          "named": true
-        },
-        {
-          "type": "collection_literal",
-          "named": true
-        },
-        {
-          "type": "comparison_expression",
-          "named": true
-        },
-        {
-          "type": "conjunction_expression",
-          "named": true
-        },
-        {
-          "type": "control_structure_body",
-          "named": true
-        },
-        {
-          "type": "disjunction_expression",
-          "named": true
-        },
-        {
-          "type": "elvis_expression",
-          "named": true
-        },
-        {
-          "type": "equality_expression",
-          "named": true
-        },
-        {
-          "type": "hex_literal",
-          "named": true
-        },
-        {
-          "type": "if_expression",
-          "named": true
-        },
-        {
-          "type": "indexing_expression",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "jump_expression",
-          "named": true
-        },
-        {
-          "type": "lambda_literal",
-          "named": true
-        },
-        {
-          "type": "long_literal",
-          "named": true
-        },
-        {
-          "type": "multiplicative_expression",
-          "named": true
-        },
-        {
-          "type": "navigation_expression",
-          "named": true
-        },
-        {
-          "type": "object_literal",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "range_expression",
-          "named": true
-        },
-        {
-          "type": "real_literal",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "super_expression",
-          "named": true
-        },
-        {
-          "type": "this_expression",
-          "named": true
-        },
-        {
-          "type": "try_expression",
-          "named": true
-        },
-        {
-          "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "when_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "control_structure_body",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "additive_expression",
+            "named": true
+          },
+          {
+            "type": "anonymous_function",
+            "named": true
+          },
+          {
+            "type": "as_expression",
+            "named": true
+          },
+          {
+            "type": "bin_literal",
+            "named": true
+          },
+          {
+            "type": "boolean_literal",
+            "named": true
+          },
+          {
+            "type": "call_expression",
+            "named": true
+          },
+          {
+            "type": "callable_reference",
+            "named": true
+          },
+          {
+            "type": "character_literal",
+            "named": true
+          },
+          {
+            "type": "check_expression",
+            "named": true
+          },
+          {
+            "type": "collection_literal",
+            "named": true
+          },
+          {
+            "type": "comparison_expression",
+            "named": true
+          },
+          {
+            "type": "conjunction_expression",
+            "named": true
+          },
+          {
+            "type": "disjunction_expression",
+            "named": true
+          },
+          {
+            "type": "elvis_expression",
+            "named": true
+          },
+          {
+            "type": "equality_expression",
+            "named": true
+          },
+          {
+            "type": "hex_literal",
+            "named": true
+          },
+          {
+            "type": "if_expression",
+            "named": true
+          },
+          {
+            "type": "indexing_expression",
+            "named": true
+          },
+          {
+            "type": "infix_expression",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "jump_expression",
+            "named": true
+          },
+          {
+            "type": "lambda_literal",
+            "named": true
+          },
+          {
+            "type": "long_literal",
+            "named": true
+          },
+          {
+            "type": "multiplicative_expression",
+            "named": true
+          },
+          {
+            "type": "navigation_expression",
+            "named": true
+          },
+          {
+            "type": "null",
+            "named": false
+          },
+          {
+            "type": "object_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "postfix_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "range_expression",
+            "named": true
+          },
+          {
+            "type": "real_literal",
+            "named": true
+          },
+          {
+            "type": "simple_identifier",
+            "named": true
+          },
+          {
+            "type": "spread_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "super_expression",
+            "named": true
+          },
+          {
+            "type": "this_expression",
+            "named": true
+          },
+          {
+            "type": "try_expression",
+            "named": true
+          },
+          {
+            "type": "unsigned_literal",
+            "named": true
+          },
+          {
+            "type": "when_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5268,20 +5268,27 @@
   {
     "type": "lambda_literal",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "lambda_parameters",
-          "named": true
-        },
-        {
-          "type": "statements",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "statements",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "lambda_parameters",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5875,20 +5875,31 @@
   {
     "type": "object_literal",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "class_body",
-          "named": true
-        },
-        {
-          "type": "delegation_specifier",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "class_body",
+            "named": true
+          }
+        ]
+      },
+      "delegation_specifiers": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "delegation_specifier",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3649,60 +3649,127 @@
   {
     "type": "function_declaration",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "function_body",
-          "named": true
-        },
-        {
-          "type": "function_type",
-          "named": true
-        },
-        {
-          "type": "function_value_parameters",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        },
-        {
-          "type": "not_nullable_type",
-          "named": true
-        },
-        {
-          "type": "nullable_type",
-          "named": true
-        },
-        {
-          "type": "parenthesized_type",
-          "named": true
-        },
-        {
-          "type": "simple_identifier",
-          "named": true
-        },
-        {
-          "type": "type_constraints",
-          "named": true
-        },
-        {
-          "type": "type_modifiers",
-          "named": true
-        },
-        {
-          "type": "type_parameters",
-          "named": true
-        },
-        {
-          "type": "user_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "function_body",
+            "named": true
+          }
+        ]
+      },
+      "constraints": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_constraints",
+            "named": true
+          }
+        ]
+      },
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "simple_identifier",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "function_value_parameters",
+            "named": true
+          }
+        ]
+      },
+      "receiver": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "dynamic",
+            "named": false
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized_type",
+            "named": true
+          },
+          {
+            "type": "type_modifiers",
+            "named": true
+          },
+          {
+            "type": "user_type",
+            "named": true
+          }
+        ]
+      },
+      "return_type": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "dynamic",
+            "named": false
+          },
+          {
+            "type": "function_type",
+            "named": true
+          },
+          {
+            "type": "not_nullable_type",
+            "named": true
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized_type",
+            "named": true
+          },
+          {
+            "type": "type_modifiers",
+            "named": true
+          },
+          {
+            "type": "user_type",
+            "named": true
+          }
+        ]
+      },
+      "type_parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_parameters",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6521,20 +6521,39 @@
   {
     "type": "primary_constructor",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "class_parameter",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        }
-      ]
+    "fields": {
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "class_parameter",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -7333,28 +7352,55 @@
   {
     "type": "secondary_constructor",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "constructor_delegation_call",
-          "named": true
-        },
-        {
-          "type": "function_value_parameters",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        },
-        {
-          "type": "statements",
-          "named": true
-        }
-      ]
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "statements",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      },
+      "delegation": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "constructor_delegation_call",
+            "named": true
+          }
+        ]
+      },
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "function_value_parameters",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8134,48 +8134,71 @@
   {
     "type": "type_alias",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "function_type",
-          "named": true
-        },
-        {
-          "type": "modifiers",
-          "named": true
-        },
-        {
-          "type": "not_nullable_type",
-          "named": true
-        },
-        {
-          "type": "nullable_type",
-          "named": true
-        },
-        {
-          "type": "parenthesized_type",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
-          "named": true
-        },
-        {
-          "type": "type_modifiers",
-          "named": true
-        },
-        {
-          "type": "type_parameters",
-          "named": true
-        },
-        {
-          "type": "user_type",
-          "named": true
-        }
-      ]
+    "fields": {
+      "modifiers": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "modifiers",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_identifier",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "dynamic",
+            "named": false
+          },
+          {
+            "type": "function_type",
+            "named": true
+          },
+          {
+            "type": "not_nullable_type",
+            "named": true
+          },
+          {
+            "type": "nullable_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized_type",
+            "named": true
+          },
+          {
+            "type": "type_modifiers",
+            "named": true
+          },
+          {
+            "type": "user_type",
+            "named": true
+          }
+        ]
+      },
+      "type_parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "type_parameters",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -85,16 +85,17 @@ class X {
     (type_identifier)
     (class_body
       (function_declaration
-        (modifiers
-          (annotation (user_type (type_identifier)))
-          (annotation (user_type (type_identifier))))
-        (simple_identifier)
-        (function_value_parameters)
-        (user_type (type_identifier))
-      )
-    )
-  )
-)
+        modifiers: (modifiers
+          (annotation
+            (user_type
+              (type_identifier)))
+          (annotation
+            (user_type
+              (type_identifier))))
+        name: (simple_identifier)
+        parameters: (function_value_parameters)
+        return_type: (user_type
+          (type_identifier))))))
 
 =====================
 Annotated functions
@@ -107,13 +108,13 @@ fun foo() = bar {}
 
 (source_file
   (function_declaration
-    (modifiers
+    modifiers: (modifiers
       (annotation
         (user_type
           (type_identifier))))
-    (simple_identifier)
-    (function_value_parameters)
-    (function_body
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
       (call_expression
         (simple_identifier)
         (call_suffix

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -47,9 +47,18 @@ var x: Int
 ---
 
 (source_file
-    (property_declaration
-        (modifiers (annotation (use_site_target) (user_type (type_identifier)) (user_type (type_identifier))))
-        (variable_declaration (simple_identifier) (user_type (type_identifier)))))
+  (property_declaration
+    modifiers: (modifiers
+      (annotation
+        (use_site_target)
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier))))
+    variable: (variable_declaration
+      (simple_identifier)
+      (user_type
+        (type_identifier)))))
 
 ==================
 Multiple annotations on a variable
@@ -67,16 +76,18 @@ class X {
     name: (type_identifier)
     body: (class_body
       (property_declaration
-        (modifiers
-          (annotation (user_type (type_identifier)))
-          (annotation (user_type (type_identifier)))
+        modifiers: (modifiers
+          (annotation
+            (user_type
+              (type_identifier)))
+          (annotation
+            (user_type
+              (type_identifier)))
           (member_modifier))
-        (variable_declaration (simple_identifier) (user_type (type_identifier)))
-      )
-    )
-  )
-)
-
+        variable: (variable_declaration
+          (simple_identifier)
+          (user_type
+            (type_identifier)))))))
 
 ==================
 Multiple annotations on a function

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -9,8 +9,11 @@ class Empty
 
 (source_file
   (class_declaration
-        (modifiers (annotation (user_type (type_identifier))))
-        (type_identifier)))
+    modifiers: (modifiers
+      (annotation
+        (user_type
+          (type_identifier))))
+    name: (type_identifier)))
 
 ==================
 Annotations with use-site-target
@@ -22,11 +25,17 @@ class Empty(@field:Test val x: Boolean)
 
 (source_file
   (class_declaration
-        (type_identifier)
-        (primary_constructor (class_parameter
-            (modifiers (annotation (use_site_target) (user_type (type_identifier))))
-            (simple_identifier)
-            (user_type (type_identifier))))))
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
+      (class_parameter
+        (modifiers
+          (annotation
+            (use_site_target)
+            (user_type
+              (type_identifier))))
+        (simple_identifier)
+        (user_type
+          (type_identifier))))))
 
 ==================
 Multi-annotations
@@ -55,8 +64,8 @@ class X {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (property_declaration
         (modifiers
           (annotation (user_type (type_identifier)))
@@ -82,8 +91,8 @@ class X {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (function_declaration
         modifiers: (modifiers
           (annotation

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -27,7 +27,7 @@ class Empty(@field:Test val x: Boolean)
   (class_declaration
     name: (type_identifier)
     primary_constructor: (primary_constructor
-      (class_parameter
+      parameters: (class_parameter
         (modifiers
           (annotation
             (use_site_target)

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -13,9 +13,9 @@ class Foo(){
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (primary_constructor)
-    (class_body
+    name: (type_identifier)
+    primary_constructor: (primary_constructor)
+    body: (class_body
       (property_declaration
         (variable_declaration
           (simple_identifier)))

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -46,9 +46,9 @@ fun main(){
 
 (source_file
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters)
-    (function_body
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
       (statements
         (property_declaration
           (variable_declaration

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -17,7 +17,7 @@ class Foo(){
     primary_constructor: (primary_constructor)
     body: (class_body
       (property_declaration
-        (variable_declaration
+        variable: (variable_declaration
           (simple_identifier)))
       (secondary_constructor
       (function_value_parameters
@@ -51,7 +51,7 @@ fun main(){
     body: (function_body
       (statements
         (property_declaration
-          (variable_declaration
+          variable: (variable_declaration
             (simple_identifier)
             (user_type
               (type_identifier)

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -20,12 +20,12 @@ class Foo(){
         variable: (variable_declaration
           (simple_identifier)))
       (secondary_constructor
-      (function_value_parameters
-        (parameter
-          (simple_identifier)
-          (user_type
-            (type_identifier))))
-        (statements
+        parameters: (function_value_parameters
+          (parameter
+            (simple_identifier)
+            (user_type
+              (type_identifier))))
+        body: (statements
           (assignment
             (directly_assignable_expression
               (this_expression)

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -9,10 +9,10 @@ class Empty2 {}
 
 (source_file
   (class_declaration
-    (type_identifier))
+    name: (type_identifier))
   (class_declaration
-    (type_identifier)
-    (class_body)))
+    name: (type_identifier)
+    body: (class_body)))
 
 ================================================================================
 Class with methods
@@ -28,8 +28,8 @@ class HelloWorld {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (function_declaration
         name: (simple_identifier)
         parameters: (function_value_parameters)
@@ -49,11 +49,11 @@ class Container<T> {}
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (type_parameters
+    name: (type_identifier)
+    type_parameters: (type_parameters
       (type_parameter
         (type_identifier)))
-    (class_body)))
+    body: (class_body)))
 
 ================================================================================
 Class with methods and expressions
@@ -69,8 +69,8 @@ class Strings {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (function_declaration
         name: (simple_identifier)
         parameters: (function_value_parameters)
@@ -98,11 +98,11 @@ internal open class Test {
 
 (source_file
   (class_declaration
-    (modifiers
+    modifiers: (modifiers
       (visibility_modifier)
       (inheritance_modifier))
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (function_declaration
         modifiers: (modifiers
           (visibility_modifier)
@@ -142,10 +142,10 @@ data class Vector2D(
 
 (source_file
   (class_declaration
-    (modifiers
+    modifiers: (modifiers
       (class_modifier))
-    (type_identifier)
-    (primary_constructor
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
       (class_parameter
         (simple_identifier)
         (user_type
@@ -169,21 +169,21 @@ class D : SomeInterface
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (delegation_specifier
+    name: (type_identifier)
+    delegation_specifiers: (delegation_specifier
       (constructor_invocation
         (user_type
           (type_identifier))
         (value_arguments)))
-    (class_body))
+    body: (class_body))
   (class_declaration
-    (type_identifier)
-    (primary_constructor
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
       (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier))))
-    (delegation_specifier
+    delegation_specifiers: (delegation_specifier
       (constructor_invocation
         (user_type
           (type_identifier))
@@ -191,8 +191,8 @@ class D : SomeInterface
           (value_argument
             (simple_identifier))))))
   (class_declaration
-    (type_identifier)
-    (delegation_specifier
+    name: (type_identifier)
+    delegation_specifiers: (delegation_specifier
       (user_type
         (type_identifier)))))
 
@@ -210,8 +210,8 @@ class Something {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (property_declaration
         (variable_declaration
           (simple_identifier)
@@ -245,8 +245,8 @@ class Test(x: Int, y: Int) {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (primary_constructor
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
       (class_parameter
         (simple_identifier)
         (user_type
@@ -255,8 +255,9 @@ class Test(x: Int, y: Int) {
         (simple_identifier)
         (user_type
           (type_identifier))))
-    (class_body
-      (secondary_constructor (function_value_parameters)
+    body: (class_body
+      (secondary_constructor
+        (function_value_parameters)
         (constructor_delegation_call
           (value_arguments
             (value_argument
@@ -284,8 +285,8 @@ enum class Color(val rgb: Int) {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (enum_class_body
+    name: (type_identifier)
+    body: (enum_class_body
       (enum_entry
         (simple_identifier))
       (enum_entry
@@ -295,13 +296,13 @@ enum class Color(val rgb: Int) {
       (enum_entry
         (simple_identifier))))
   (class_declaration
-    (type_identifier)
-    (primary_constructor
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
       (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier))))
-    (enum_class_body
+    body: (enum_class_body
       (enum_entry
         (simple_identifier)
         (value_arguments
@@ -346,10 +347,10 @@ data class JwtConfiguration(
 
 (source_file
   (class_declaration
-    (modifiers
+    modifiers: (modifiers
       (class_modifier))
-    (type_identifier)
-    (primary_constructor
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
       (class_parameter
         (simple_identifier)
         (user_type
@@ -370,13 +371,13 @@ value class Password(private val s: String)
 
 (source_file
   (class_declaration
-    (modifiers
+    modifiers: (modifiers
       (annotation
         (user_type
           (type_identifier)))
       (class_modifier))
-    (type_identifier)
-    (primary_constructor
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
       (class_parameter
         (modifiers
           (visibility_modifier))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -31,13 +31,13 @@ class HelloWorld {
     (type_identifier)
     (class_body
       (function_declaration
-       (simple_identifier)
-       (function_value_parameters)
-       (function_body))
+        name: (simple_identifier)
+        parameters: (function_value_parameters)
+        body: (function_body))
       (function_declaration
-       (simple_identifier)
-       (function_value_parameters)
-       (function_body)))))
+        name: (simple_identifier)
+        parameters: (function_value_parameters)
+        body: (function_body)))))
 
 ================================================================================
 Generic class
@@ -72,16 +72,16 @@ class Strings {
     (type_identifier)
     (class_body
       (function_declaration
-       (simple_identifier)
-       (function_value_parameters)
-       (function_body
-        (string_literal)))
+        name: (simple_identifier)
+        parameters: (function_value_parameters)
+        body: (function_body
+          (string_literal)))
       (function_declaration
-       (simple_identifier)
-       (function_value_parameters)
-       (function_body
-        (additive_expression
+        name: (simple_identifier)
+        parameters: (function_value_parameters)
+        body: (function_body
           (additive_expression
+            (additive_expression
               (string_literal)
               (string_literal))
             (string_literal)))))))
@@ -104,12 +104,12 @@ internal open class Test {
     (type_identifier)
     (class_body
       (function_declaration
-        (modifiers
-         (visibility_modifier)
-         (inheritance_modifier)
-         (function_modifier))
-        (simple_identifier)
-        (function_value_parameters)))))
+        modifiers: (modifiers
+          (visibility_modifier)
+          (inheritance_modifier)
+          (function_modifier))
+        name: (simple_identifier)
+        parameters: (function_value_parameters)))))
 
 ================================================================================
 Objects
@@ -126,8 +126,8 @@ object Singleton {
     (type_identifier)
     (class_body
       (function_declaration
-       (simple_identifier)
-       (function_value_parameters)))))
+        name: (simple_identifier)
+        parameters: (function_value_parameters)))))
 
 ================================================================================
 Primary constructors
@@ -318,11 +318,11 @@ enum class Color(val rgb: Int) {
           (value_argument
             (hex_literal))))
       (function_declaration
-        (modifiers
+        modifiers: (modifiers
           (member_modifier))
-        (simple_identifier)
-        (function_value_parameters)
-        (function_body
+        name: (simple_identifier)
+        parameters: (function_value_parameters)
+        body: (function_body
           (call_expression
             (navigation_expression
               (simple_identifier)

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -384,3 +384,33 @@ value class Password(private val s: String)
         (simple_identifier)
         (user_type
           (type_identifier))))))
+
+================================================================================
+Anonymous initializer
+================================================================================
+
+class MyClass(name: String) {
+  init {
+    println(name)
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    name: (type_identifier)
+    primary_constructor: (primary_constructor
+      parameters: (class_parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier))))
+    body: (class_body
+      (anonymous_initializer
+        body: (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (simple_identifier))))))))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -213,23 +213,23 @@ class Something {
     name: (type_identifier)
     body: (class_body
       (property_declaration
-        (variable_declaration
+        variable: (variable_declaration
           (simple_identifier)
           (user_type
             (type_identifier)))
-        (integer_literal))
+        expression: (integer_literal))
       (property_declaration
-        (variable_declaration
+        variable: (variable_declaration
           (simple_identifier)
           (nullable_type
             (user_type
               (type_identifier)))))
       (property_declaration
-        (variable_declaration
+        variable: (variable_declaration
           (simple_identifier)
           (user_type
             (type_identifier)))
-        (getter
+        getter: (getter
           (function_body
             (simple_identifier)))))))
 

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -123,8 +123,8 @@ object Singleton {
 
 (source_file
   (object_declaration
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (function_declaration
         name: (simple_identifier)
         parameters: (function_value_parameters)))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -414,3 +414,29 @@ class MyClass(name: String) {
               (value_arguments
                 (value_argument
                   (simple_identifier))))))))))
+
+================================================================================
+Companion object
+================================================================================
+
+class C() {
+  private companion object Factory : D() {}
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    name: (type_identifier)
+    primary_constructor: (primary_constructor)
+    body: (class_body
+      (companion_object
+        modifiers: (modifiers
+          (visibility_modifier))
+        name: (type_identifier)
+        delegation_specifiers: (delegation_specifier
+          (constructor_invocation
+            (user_type
+              (type_identifier))
+            (value_arguments)))
+        body: (class_body)))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -146,11 +146,11 @@ data class Vector2D(
       (class_modifier))
     name: (type_identifier)
     primary_constructor: (primary_constructor
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier)))
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier))))))
@@ -179,7 +179,7 @@ class D : SomeInterface
   (class_declaration
     name: (type_identifier)
     primary_constructor: (primary_constructor
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier))))
@@ -247,18 +247,18 @@ class Test(x: Int, y: Int) {
   (class_declaration
     name: (type_identifier)
     primary_constructor: (primary_constructor
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier)))
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier))))
     body: (class_body
       (secondary_constructor
-        (function_value_parameters)
-        (constructor_delegation_call
+        parameters: (function_value_parameters)
+        delegation: (constructor_delegation_call
           (value_arguments
             (value_argument
               (integer_literal))
@@ -298,7 +298,7 @@ enum class Color(val rgb: Int) {
   (class_declaration
     name: (type_identifier)
     primary_constructor: (primary_constructor
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier))))
@@ -351,11 +351,11 @@ data class JwtConfiguration(
       (class_modifier))
     name: (type_identifier)
     primary_constructor: (primary_constructor
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier)))
-      (class_parameter
+      parameters: (class_parameter
         (simple_identifier)
         (user_type
           (type_identifier))))))
@@ -378,7 +378,7 @@ value class Password(private val s: String)
       (class_modifier))
     name: (type_identifier)
     primary_constructor: (primary_constructor
-      (class_parameter
+      parameters: (class_parameter
         (modifiers
           (visibility_modifier))
         (simple_identifier)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -209,11 +209,11 @@ expect fun randomUUID(): String
 
 (source_file
   (function_declaration
-    (modifiers
+    modifiers: (modifiers
       (platform_modifier))
-    (simple_identifier)
-    (function_value_parameters)
-    (user_type
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    return_type: (user_type
       (type_identifier))))
 
 ================================================================================
@@ -346,9 +346,9 @@ when (dir) {
 
 (source_file
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters)
-    (function_body
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
       (statements
         (property_declaration
           (variable_declaration
@@ -495,11 +495,11 @@ class Square() : Rectangle(), Polygon {
         (type_identifier)))
     (class_body
       (function_declaration
-        (modifiers
+        modifiers: (modifiers
           (member_modifier))
-        (simple_identifier)
-        (function_value_parameters)
-        (function_body
+        name: (simple_identifier)
+        parameters: (function_value_parameters)
+        body: (function_body
           (statements
             (call_expression
               (navigation_expression

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -100,13 +100,13 @@ val y = when(x){
 
 (source_file
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (integer_literal))
+    expression: (integer_literal))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (when_expression
+    expression: (when_expression
       (when_subject
         (simple_identifier))
       (when_entry
@@ -154,13 +154,13 @@ val MyDate.s: String get() = "hello"
 
 (source_file
   (property_declaration
-    (user_type
+    receiver: (user_type
       (type_identifier))
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier)
       (user_type
         (type_identifier)))
-    (getter
+    getter: (getter
       (function_body
         (string_literal)))))
 
@@ -174,9 +174,9 @@ val x = expect(1)
 
 (source_file
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (call_expression
+    expression: (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments
@@ -264,30 +264,30 @@ val a = a<2>(3)
 
 (source_file
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (comparison_expression
+    expression: (comparison_expression
       (simple_identifier)
       (simple_identifier)))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (comparison_expression
+    expression: (comparison_expression
       (simple_identifier)
       (simple_identifier)))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (comparison_expression
+    expression: (comparison_expression
       (comparison_expression
         (simple_identifier)
         (simple_identifier))
       (simple_identifier)))
   (line_comment)
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (call_expression
+    expression: (call_expression
       (simple_identifier)
       (call_suffix
         (type_arguments
@@ -298,9 +298,9 @@ val a = a<2>(3)
           (value_argument
             (simple_identifier))))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (comparison_expression
+    expression: (comparison_expression
       (comparison_expression
         (simple_identifier)
         (integer_literal))
@@ -351,9 +351,9 @@ when (dir) {
     body: (function_body
       (statements
         (property_declaration
-          (variable_declaration
+          variable: (variable_declaration
             (simple_identifier))
-          (navigation_expression
+          expression: (navigation_expression
             (simple_identifier)
             (navigation_suffix
               (simple_identifier))))
@@ -381,9 +381,9 @@ when (dir) {
       (control_structure_body
         (statements
           (property_declaration
-            (variable_declaration
+            variable: (variable_declaration
               (simple_identifier))
-            (navigation_expression
+            expression: (navigation_expression
               (simple_identifier)
               (navigation_suffix
                 (simple_identifier))))
@@ -422,49 +422,49 @@ val comments = """ // and here """
 
 (source_file
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (call_expression
+    expression: (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments
           (value_argument
             (string_literal))))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (call_expression
+    expression: (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments
           (value_argument
             (string_literal))))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (call_expression
+    expression: (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments
           (value_argument
             (string_literal))))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (call_expression
+    expression: (call_expression
       (simple_identifier)
       (call_suffix
         (value_arguments
           (value_argument
             (string_literal))))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (string_literal))
+    expression: (string_literal))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (string_literal)))
+    expression: (string_literal)))
 
 ================================================================================
 Qualified this/super expressions
@@ -536,3 +536,4 @@ class Square() : Rectangle(), Polygon {
                   (simple_identifier)))
               (call_suffix
                 (value_arguments)))))))))
+

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -324,13 +324,13 @@ foo.forEach { (index, value) -> 2 }
     (call_suffix
       (annotated_lambda
         (lambda_literal
-          (lambda_parameters
+          parameters: (lambda_parameters
             (multi_variable_declaration
               (variable_declaration
                 (simple_identifier))
               (variable_declaration
                 (simple_identifier))))
-          (statements
+          body: (statements
             (integer_literal)))))))
 
 ================================================================================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -483,17 +483,17 @@ class Square() : Rectangle(), Polygon {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (primary_constructor)
-    (delegation_specifier
+    name: (type_identifier)
+    primary_constructor: (primary_constructor)
+    delegation_specifiers: (delegation_specifier
       (constructor_invocation
         (user_type
           (type_identifier))
         (value_arguments)))
-    (delegation_specifier
+    delegation_specifiers: (delegation_specifier
       (user_type
         (type_identifier)))
-    (class_body
+    body: (class_body
       (function_declaration
         modifiers: (modifiers
           (member_modifier))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -107,17 +107,17 @@ val y = when(x){
     variable: (variable_declaration
       (simple_identifier))
     expression: (when_expression
-      (when_subject
+      subject: (when_subject
         (simple_identifier))
-      (when_entry
-        (when_condition
+      entry: (when_entry
+        condition: (when_condition
           (integer_literal))
-        (control_structure_body
+        body: (control_structure_body
           (boolean_literal)))
-      (when_entry
-        (when_condition
+      entry: (when_entry
+        condition: (when_condition
           (integer_literal))
-        (control_structure_body
+        body: (control_structure_body
           (boolean_literal))))))
 
 ================================================================================
@@ -132,16 +132,16 @@ when (this) {
 
 (source_file
   (when_expression
-    (when_subject
+    subject: (when_subject
       (this_expression))
-    (when_entry
-      (when_condition
+    entry: (when_entry
+      condition: (when_condition
         (type_test
           (user_type
             (type_identifier)
             (type_arguments
               (type_projection)))))
-      (control_structure_body
+      body: (control_structure_body
         (jump_expression)))))
 
 ================================================================================
@@ -373,12 +373,12 @@ when (dir) {
               (simple_identifier)))
           (simple_identifier)))))
   (when_expression
-    (when_subject
+    subject: (when_subject
       (simple_identifier))
-    (when_entry
-      (when_condition
+    entry: (when_entry
+      condition: (when_condition
         (integer_literal))
-      (control_structure_body
+      body: (control_structure_body
         (statements
           (property_declaration
             variable: (variable_declaration
@@ -536,4 +536,55 @@ class Square() : Rectangle(), Polygon {
                   (simple_identifier)))
               (call_suffix
                 (value_arguments)))))))))
+
+================================================================================
+Try expression
+================================================================================
+
+val x = try {
+    something()
+  } catch (e: SomeException) {
+    handle()
+  } catch (e: SomeOtherException) {
+    handle()
+  } finally {
+    something()
+  }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    variable: (variable_declaration
+      (simple_identifier))
+    expression: (try_expression
+      body: (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments))))
+      catch: (catch_block
+        (simple_identifier)
+        (user_type
+          (type_identifier))
+        body: (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments)))))
+      catch: (catch_block
+        (simple_identifier)
+        (user_type
+          (type_identifier))
+        body: (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments)))))
+      finally: (finally_block
+        body: (statements
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments))))))))
 

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -228,9 +228,10 @@ val anon = fun()
   (anonymous_function
   (function_value_parameters))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (anonymous_function (function_value_parameters))))
+    expression: (anonymous_function
+      (function_value_parameters))))
 
 ==================
 Anonymous function with parameters
@@ -249,14 +250,14 @@ val anon = fun(x: Int)
       (user_type
         (type_identifier)))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (anonymous_function
-    (function_value_parameters
-      (parameter
-        (simple_identifier)
-        (user_type
-          (type_identifier)))))))
+    expression: (anonymous_function
+      (function_value_parameters
+        (parameter
+          (simple_identifier)
+          (user_type
+            (type_identifier)))))))
 
 ==================
 Anonymous function with return type
@@ -273,9 +274,9 @@ val anon = fun(): Int
     (user_type
       (type_identifier)))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (anonymous_function
+    expression: (anonymous_function
       (function_value_parameters)
       (user_type
         (type_identifier)))))
@@ -307,16 +308,16 @@ val anon = fun() { assert(true) }
               (value_argument
                 (boolean_literal))))))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (anonymous_function
+    expression: (anonymous_function
       (function_value_parameters)
       (function_body
         (boolean_literal))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (anonymous_function
+    expression: (anonymous_function
       (function_value_parameters)
       (function_body
         (statements

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -226,12 +226,12 @@ val anon = fun()
 
 (source_file
   (anonymous_function
-  (function_value_parameters))
+    parameters: (function_value_parameters))
   (property_declaration
     variable: (variable_declaration
       (simple_identifier))
     expression: (anonymous_function
-      (function_value_parameters))))
+      parameters: (function_value_parameters))))
 
 ==================
 Anonymous function with parameters
@@ -244,16 +244,16 @@ val anon = fun(x: Int)
 
 (source_file
   (anonymous_function
-  (function_value_parameters
-    (parameter
-      (simple_identifier)
-      (user_type
-        (type_identifier)))))
+    parameters: (function_value_parameters
+      (parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier)))))
   (property_declaration
     variable: (variable_declaration
       (simple_identifier))
     expression: (anonymous_function
-      (function_value_parameters
+      parameters: (function_value_parameters
         (parameter
           (simple_identifier)
           (user_type
@@ -270,15 +270,15 @@ val anon = fun(): Int
 
 (source_file
   (anonymous_function
-    (function_value_parameters)
-    (user_type
+    parameters: (function_value_parameters)
+    return_type: (user_type
       (type_identifier)))
   (property_declaration
     variable: (variable_declaration
       (simple_identifier))
     expression: (anonymous_function
-      (function_value_parameters)
-      (user_type
+      parameters: (function_value_parameters)
+      return_type: (user_type
         (type_identifier)))))
 
 ==================
@@ -294,12 +294,12 @@ val anon = fun() { assert(true) }
 
 (source_file
   (anonymous_function
-    (function_value_parameters)
-    (function_body
+    parameters: (function_value_parameters)
+    body: (function_body
       (boolean_literal)))
   (anonymous_function
-    (function_value_parameters)
-    (function_body
+    parameters: (function_value_parameters)
+    body: (function_body
       (statements
         (call_expression
           (simple_identifier)
@@ -311,15 +311,15 @@ val anon = fun() { assert(true) }
     variable: (variable_declaration
       (simple_identifier))
     expression: (anonymous_function
-      (function_value_parameters)
-      (function_body
+      parameters: (function_value_parameters)
+      body: (function_body
         (boolean_literal))))
   (property_declaration
     variable: (variable_declaration
       (simple_identifier))
     expression: (anonymous_function
-      (function_value_parameters)
-      (function_body
+      parameters: (function_value_parameters)
+      body: (function_body
         (statements
           (call_expression
             (simple_identifier)

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -8,8 +8,9 @@ fun main() {}
 
 (source_file
   (function_declaration
-    (simple_identifier) (function_value_parameters)
-    (function_body)))
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body)))
 
 ==================
 Generic functions
@@ -21,9 +22,12 @@ fun <T> test() {}
 
 (source_file
   (function_declaration
-    (type_parameters (type_parameter (type_identifier)))
-    (simple_identifier) (function_value_parameters)
-    (function_body)))
+    type_parameters: (type_parameters
+      (type_parameter
+        (type_identifier)))
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body)))
 
 ==================
 Generic functions with parameters
@@ -34,20 +38,20 @@ fun <T: Int> bar(foo: Int): T {}
 ---
 (source_file
   (function_declaration
-    (type_parameters
+    type_parameters: (type_parameters
       (type_parameter
         (type_identifier)
         (user_type
           (type_identifier))))
-    (simple_identifier)
-    (function_value_parameters
+    name: (simple_identifier)
+    parameters: (function_value_parameters
       (parameter
         (simple_identifier)
         (user_type
           (type_identifier))))
-    (user_type
+    return_type: (user_type
       (type_identifier))
-    (function_body)))
+    body: (function_body)))
 
 ==================
 Functions with parameters
@@ -61,26 +65,56 @@ fun sum(a: Int, b: Int) = a + b
 
 (source_file
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters
+    name: (simple_identifier)
+    parameters: (function_value_parameters
       (parameter
         (simple_identifier)
         (user_type
           (type_identifier)
-          (type_arguments (type_projection (user_type (type_identifier)))))))
-    (function_body))
+          (type_arguments
+            (type_projection
+              (user_type
+                (type_identifier)))))))
+    body: (function_body))
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters
+    name: (simple_identifier)
+    parameters: (function_value_parameters
       (parameter
         (simple_identifier)
-        (user_type (type_identifier)))
+        (user_type
+          (type_identifier)))
       (parameter
         (simple_identifier)
-        (user_type (type_identifier))))
-    (function_body
+        (user_type
+          (type_identifier))))
+    body: (function_body
       (additive_expression
         (simple_identifier)
+        (simple_identifier)))))
+
+==================
+Functions with receivers
+==================
+
+fun Int.add(other: Int): Int = this + other
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    receiver: (user_type
+      (type_identifier))
+    name: (simple_identifier)
+    parameters: (function_value_parameters
+      (parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier))))
+    return_type: (user_type
+      (type_identifier))
+    body: (function_body
+      (additive_expression
+        (this_expression)
         (simple_identifier)))))
 
 ==================
@@ -93,10 +127,12 @@ fun answerToTheUltimateQuestionOfLifeTheUniverseAndEverything(): Int = 42
 
 (source_file
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters)
-    (user_type (type_identifier))
-    (function_body (integer_literal))))
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    return_type: (user_type
+      (type_identifier))
+    body: (function_body
+      (integer_literal))))
 
 ==================
 Functions with return calls
@@ -110,15 +146,15 @@ fun foo(p0: Int): Long {
 
 (source_file
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters
-    (parameter
-      (simple_identifier)
-      (user_type
-        (type_identifier))))
-    (user_type
+    name: (simple_identifier)
+    parameters: (function_value_parameters
+      (parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier))))
+    return_type: (user_type
       (type_identifier))
-    (function_body
+    body: (function_body
       (statements
         (jump_expression
           (call_expression
@@ -139,11 +175,11 @@ override fun boo() = foo()
 
 (source_file
   (function_declaration
-    (modifiers
+    modifiers: (modifiers
       (member_modifier))
-    (simple_identifier)
-    (function_value_parameters)
-    (function_body
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
       (call_expression
         (simple_identifier)
         (call_suffix
@@ -162,9 +198,9 @@ fun test() {
 
 (source_file
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters)
-    (function_body
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
       (statements
         (assignment
           (directly_assignable_expression
@@ -301,6 +337,7 @@ fun `this is a test function`() = true
 
 (source_file
   (function_declaration
-   (simple_identifier)
-   (function_value_parameters)
-   (function_body (boolean_literal))))
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
+      (boolean_literal))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -163,3 +163,21 @@ assertEquals("\u214E\uA7B5\u2CEF", "\u2132\uA7B4\u2CEF".lowercase())
                 (simple_identifier)))
             (call_suffix
               (value_arguments))))))))
+
+================================================================================
+Object literals
+================================================================================
+
+val x = object : D {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    variable: (variable_declaration
+      (simple_identifier))
+    expression: (object_literal
+      delegation_specifiers: (delegation_specifier
+        (user_type
+          (type_identifier)))
+      body: (class_body))))

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -57,9 +57,9 @@ fun foo()  {
     body: (function_body
       (statements
         (property_declaration
-          (variable_declaration
+          variable: (variable_declaration
             (simple_identifier))
-          (conjunction_expression
+          expression: (conjunction_expression
             (simple_identifier)
             (simple_identifier)))))))
 
@@ -121,9 +121,9 @@ fun foo() {
     body: (function_body
       (statements
         (property_declaration
-          (variable_declaration
+          variable: (variable_declaration
             (simple_identifier))
-          (elvis_expression
+          expression: (elvis_expression
             (elvis_expression
               (call_expression
                 (navigation_expression
@@ -158,7 +158,7 @@ class Foo {
     name: (type_identifier)
     body: (class_body
       (property_declaration
-        (variable_declaration
+        variable: (variable_declaration
           (simple_identifier)
           (user_type
             (type_identifier))))

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -206,11 +206,11 @@ else boo()
 
 (source_file
   (if_expression
-    (prefix_expression
+    condition: (prefix_expression
       (simple_identifier))
-    (control_structure_body
+    consequence: (control_structure_body
       (integer_literal))
-    (control_structure_body
+    alternative: (control_structure_body
       (call_expression
         (simple_identifier)
         (call_suffix
@@ -226,11 +226,11 @@ if (!foo) 3 else boo()
 
 (source_file
   (if_expression
-    (prefix_expression
+    condition: (prefix_expression
       (simple_identifier))
-    (control_structure_body
+    consequence: (control_structure_body
       (integer_literal))
-    (control_structure_body
+    alternative: (control_structure_body
       (call_expression
         (simple_identifier)
         (call_suffix

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -95,11 +95,11 @@ class Foo
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (delegation_specifier
+    name: (type_identifier)
+    delegation_specifiers: (delegation_specifier
       (user_type
         (type_identifier)))
-    (class_body)))
+    body: (class_body)))
 
 ================================================================================
 Question mark after newline
@@ -155,8 +155,8 @@ class Foo {
 
 (source_file
   (class_declaration
-    (type_identifier)
-    (class_body
+    name: (type_identifier)
+    body: (class_body
       (property_declaration
         (variable_declaration
           (simple_identifier)

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -29,13 +29,14 @@ Eq after newline
 fun foo()
     = 1
 
----
+--------------------------------------------------------------------------------
+
 (source_file
-   (function_declaration
-    (simple_identifier)
-    (function_value_parameters)
-    (function_body 
-    (integer_literal))))
+  (function_declaration
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
+      (integer_literal))))
 
 ================================================================================
 Binary operator after newline
@@ -50,15 +51,17 @@ fun foo()  {
 --------------------------------------------------------------------------------
 
 (source_file
-  (function_declaration (simple_identifier) (function_value_parameters)
-     (function_body
-        (statements
-           (property_declaration
-              (variable_declaration
-               (simple_identifier))
-              (conjunction_expression
-               (simple_identifier)
-               (simple_identifier)))))))
+  (function_declaration
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
+      (statements
+        (property_declaration
+          (variable_declaration
+            (simple_identifier))
+          (conjunction_expression
+            (simple_identifier)
+            (simple_identifier)))))))
 
 ================================================================================
 Open brace after newline
@@ -71,11 +74,11 @@ fun foo():String
 
 (source_file
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters)
-    (user_type
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    return_type: (user_type
       (type_identifier))
-    (function_body
+    body: (function_body
       (statements
         (jump_expression
           (string_literal))))))
@@ -113,9 +116,9 @@ fun foo() {
 
 (source_file
   (function_declaration
-   (simple_identifier)
-  (function_value_parameters)
-    (function_body
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
       (statements
         (property_declaration
           (variable_declaration

--- a/test/corpus/soft_keywords.txt
+++ b/test/corpus/soft_keywords.txt
@@ -15,7 +15,7 @@ fun foo() {
     body: (function_body
       (statements
         (property_declaration
-          (variable_declaration
+          variable: (variable_declaration
             (simple_identifier))
           (call_expression
             (simple_identifier)

--- a/test/corpus/soft_keywords.txt
+++ b/test/corpus/soft_keywords.txt
@@ -8,16 +8,23 @@ fun foo() {
   actual[0]++
 }
 
----
 (source_file
-  (function_declaration (simple_identifier) (function_value_parameters)
-    (function_body
+  (function_declaration
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body
       (statements
-         (property_declaration
-	   (variable_declaration (simple_identifier))
-	   (call_expression (simple_identifier)
-	     (call_suffix
-	       (value_arguments (value_argument (simple_identifier))))))
-	 (postfix_expression
-	    (indexing_expression (simple_identifier)
-  	      (indexing_suffix (integer_literal))))))))
+        (property_declaration
+          (variable_declaration
+            (simple_identifier))
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments
+                (value_argument
+                  (simple_identifier))))))
+        (postfix_expression
+          (indexing_expression
+            (simple_identifier)
+            (indexing_suffix
+              (integer_literal))))))))

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -89,9 +89,9 @@ fun main() {
         (simple_identifier)
         (simple_identifier))))
   (function_declaration
-    (simple_identifier)
-    (function_value_parameters)
-    (function_body)))
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    body: (function_body)))
 
 ================================================================================
 Multiple Imports On A Single Line

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -17,9 +17,9 @@ val x = 4
         (value_argument
           (string_literal)))))
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (integer_literal)))
+    expression: (integer_literal)))
 
 ================================================================================
 Multiple file annotations

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -8,10 +8,35 @@ for (value in values) {}
 
 (source_file
   (for_statement
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (simple_identifier)
-    (control_structure_body)))
+    value: (simple_identifier)
+    body: (control_structure_body)))
+
+================================================================================
+For with multiple variables
+================================================================================
+
+for ((variable0, variable1) in container) {
+  then()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (for_statement
+    variables: (multi_variable_declaration
+      (variable_declaration
+        (simple_identifier))
+      (variable_declaration
+        (simple_identifier)))
+    value: (simple_identifier)
+    body: (control_structure_body
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
 
 ================================================================================
 Statements separated by semicolon
@@ -91,3 +116,43 @@ val (x, y, z) = listOf(1, 2, 3)
             (integer_literal))
           (value_argument
             (integer_literal)))))))
+
+================================================================================
+While
+================================================================================
+
+while (condition) {
+  then()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (while_statement
+    condition: (simple_identifier)
+    body: (control_structure_body
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+Do while
+================================================================================
+
+do {
+  then()
+} while (condition)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (do_while_statement
+    body: (control_structure_body
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    condition: (simple_identifier)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -23,13 +23,13 @@ override fun isDisposed(): Boolean { expectUnreached();  return false }
 
 (source_file
   (function_declaration
-    (modifiers
+    modifiers: (modifiers
       (member_modifier))
-    (simple_identifier)
-    (function_value_parameters)
-    (user_type
+    name: (simple_identifier)
+    parameters: (function_value_parameters)
+    return_type: (user_type
       (type_identifier))
-    (function_body
+    body: (function_body
       (statements
         (call_expression
           (simple_identifier)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -50,16 +50,44 @@ val ty x get () = 3
 
 (source_file
   (property_declaration
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (getter
+    getter: (getter
       (function_body
         (integer_literal))))
   (property_declaration
-    (user_type
+    receiver: (user_type
       (type_identifier))
-    (variable_declaration
+    variable: (variable_declaration
       (simple_identifier))
-    (getter
+    getter: (getter
       (function_body
         (integer_literal)))))
+
+================================================================================
+Multiple variables
+================================================================================
+
+val (x, y, z) = listOf(1, 2, 3)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    variables: (multi_variable_declaration
+      (variable_declaration
+        (simple_identifier))
+      (variable_declaration
+        (simple_identifier))
+      (variable_declaration
+        (simple_identifier)))
+    expression: (call_expression
+      (simple_identifier)
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (integer_literal))
+          (value_argument
+            (integer_literal))
+          (value_argument
+            (integer_literal)))))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -266,13 +266,13 @@ private typealias T<E> = Foo<E>
 
 (source_file
   (type_alias
-    (modifiers
+    modifiers: (modifiers
       (visibility_modifier))
-    (type_identifier)
-    (type_parameters
+    name: (type_identifier)
+    type_parameters: (type_parameters
       (type_parameter
         (type_identifier)))
-    (user_type
+    type: (user_type
       (type_identifier)
       (type_arguments
         (type_projection


### PR DESCRIPTION
Hi,

This is a continuation of /pull/74 given Vladimir Reshetnikov said they would not be pursuing it anymore.

In [Searchfox](https://searchfox.org), we leverage tree-sitter to add some information on where symbols are found. For instance if you search for the C++ symbol [mozilla::dom::MediaControlKeySource::IsOpened](https://searchfox.org/mozilla-central/search?q=symbol:_ZNK7mozilla3dom21MediaControlKeySource8IsOpenedEv), and you find 9 results in the file `dom/mediacontrol/MediaControlKeyManager.cpp`, it's super useful to know in which function each result was found (tree-sitter is what enables those `// found in` comments). We are adding Kotlin support to Searchfox, hence this PR.

For now we only use the `name` and `body` fields of `class_definition` and `function_declaration`, but since there was a pull request hanging around to add named fields everywhere I just rebased it on main.
If you think it's too much (this adds almost 2M lines to `parser.c`!), I can reduce the number of named fields. They could be useful to someone else though.