### PR TITLE
fix: support calls in assignments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -607,7 +607,6 @@ module.exports = grammar({
 
     _unary_expression: $ => choice(
       $.postfix_expression,
-      $.call_expression,
       $.indexing_expression,
       $.navigation_expression,
       $.prefix_expression,
@@ -723,6 +722,7 @@ module.exports = grammar({
       $._string_literal,
       $.callable_reference,
       $._function_literal,
+      $.call_expression,
       $.object_literal,
       $.collection_literal,
       $.this_expression,

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2427,6 +2427,10 @@
           "named": true
         },
         {
+          "type": "call_expression",
+          "named": true
+        },
+        {
           "type": "callable_reference",
           "named": true
         },

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
In Kotlin, we can write code like:

```
package annotation.test

public object Test {
    fun f1(context : Context) {
        Foo(context).elem = var1
    }
}
```

where `Foo(context).elem = var1` assigns `var1` to an object constructed in that line.

More generally, the result of calls can be shared objects that we wish to assign to. Therefore, expressions that can be on the left hand of assignments (primary expressions) need to include calls.

Test plan: parse the example given