### PR TITLE
refactor(scanner): code cleanup

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,5 +1,7 @@
+#include "tree_sitter/array.h"
+#include "tree_sitter/parser.h"
+
 #include <string.h>
-#include <tree_sitter/parser.h>
 #include <wctype.h>
 
 // Mostly a copy paste of tree-sitter-javascript/src/scanner.c
@@ -24,8 +26,6 @@ enum TokenType {
    particularly with respect to interpolation.
  */
 
-typedef char Delimiter;
-
 // Block comments are easy to parse, but strings require extra-attention.
 
 // The main problems that arise when parsing strings are:
@@ -34,87 +34,58 @@ typedef char Delimiter;
 //    sequences, but you can always write \" and \`.
 
 // To efficiently store a delimiter, we take advantage of the fact that:
-// (int)'"' == 34 && 34 % 2 == 0
+// (int)'"' == 34 && (34 & 1) == 0
 // i.e. " has an even numeric representation, so we can store a triple
 // quoted delimiter as (delimiter + 1).
 
+#define DELIMITER_LENGTH 3
+
+typedef char Delimiter;
+
 // We use a stack to keep track of the string delimiters.
-typedef struct {
-  Delimiter *arr;
-  unsigned len;
-} Stack;
+typedef Array(Delimiter) Stack;
 
-static Stack *new_stack() {
-  Delimiter *arr = malloc(TREE_SITTER_SERIALIZATION_BUFFER_SIZE);
-  if (arr == NULL) abort();
-  Stack *stack = malloc(sizeof(Stack));
-  if (stack == NULL) abort();
-  stack->arr = arr;
-  stack->len = 0;
-  return stack;
+static inline void stack_push(Stack *stack, char chr, bool triple) {
+  if (stack->size >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) abort();
+  array_push(stack, (Delimiter)(triple ? (chr + 1) : chr));
 }
 
-static void free_stack(Stack *stack) {
-  free(stack->arr);
-  free(stack);
+static inline Delimiter stack_pop(Stack *stack) {
+  if (stack->size == 0) abort();
+  return array_pop(stack);
 }
 
-static void push(Stack *stack, char chr, bool triple) {
-  if (stack->len >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) abort();
-  stack->arr[stack->len++] = (Delimiter)(triple ? (chr + 1) : chr);
-}
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
 
-static Delimiter pop(Stack *stack) {
-  if (stack->len == 0) abort();
-  return stack->arr[stack->len--];
-}
-
-static unsigned serialize_stack(Stack *stack, char *buffer) {
-  unsigned len = stack->len;
-  memcpy(buffer, stack->arr, len);
-  return len;
-}
-
-static void deserialize_stack(Stack *stack, const char *buffer, unsigned len) {
-  if (len > 0) {
-    memcpy(stack->arr, buffer, len);
-    stack->len = len;
-  } else {
-    stack->len = 0;
-  }
-}
-
-static void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
-static void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
-static void mark_end(TSLexer *lexer) { lexer->mark_end(lexer); }
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 
 // Scanner functions
 
 static bool scan_string_start(TSLexer *lexer, Stack *stack) {
   if (lexer->lookahead != '"') return false;
   advance(lexer);
-  mark_end(lexer);
-  for (unsigned count = 1; count < 3; count++) {
+  lexer->mark_end(lexer);
+  for (unsigned count = 1; count < DELIMITER_LENGTH; ++count) {
     if (lexer->lookahead != '"') {
       // It's not a triple quoted delimiter.
-      push(stack, '"', false);
+      stack_push(stack, '"', false);
       return true;
     }
     advance(lexer);
   }
-  mark_end(lexer);
-  push(stack, '"', true);
+  lexer->mark_end(lexer);
+  stack_push(stack, '"', true);
   return true;
 }
 
 static bool scan_string_content(TSLexer *lexer, Stack *stack) {
-  if (stack->len == 0) return false;  // Stack is empty. We're not in a string.
-  Delimiter end_char = stack->arr[stack->len - 1];  // peek
+  if (stack->size == 0) return false;  // Stack is empty. We're not in a string.
+  Delimiter end_char = stack->contents[stack->size - 1];  // peek
   bool is_triple = false;
   bool has_content = false;
-  if (end_char % 2 != 0) {
+  if (end_char & 1) {
     is_triple = true;
-    end_char--;
+    end_char -= 1;
   }
   while (lexer->lookahead) {
     if (lexer->lookahead == '$') {
@@ -125,9 +96,9 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack) {
         lexer->result_symbol = STRING_CONTENT;
         return has_content;
       }
-      // otherwise, if this is the start, determine if it is an 
+      // otherwise, if this is the start, determine if it is an
       // interpolated identifier.
-      // otherwise, it's just string content, so continue 
+      // otherwise, it's just string content, so continue
       advance(lexer);
       if (iswalpha(lexer->lookahead) || lexer->lookahead == '{') {
         // this must be a string interpolation, let's
@@ -135,35 +106,32 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack) {
         return false;
       }
       lexer->result_symbol = STRING_CONTENT;
-      mark_end(lexer);
+      lexer->mark_end(lexer);
       return true;
-    } 
+    }
     if (lexer->lookahead == '\\') {
       // if we see a \, then this might possibly escape a dollar sign
-      // in which case, we need to not defer to the interpolation 
-      has_content = true;
+      // in which case, we should not defer to the interpolation
       advance(lexer);
       // this dollar sign is escaped, so it must be content.
       // we consume it here so we don't enter the dollar sign case above,
-      // which leaves the possibility that it is an interpolation 
-      if (lexer->lookahead == '$') {
-        advance(lexer);
-      }
+      // which leaves the possibility that it is an interpolation
+      if (lexer->lookahead == '$') advance(lexer);
     } else if (lexer->lookahead == end_char) {
       if (is_triple) {
-        mark_end(lexer);
-        for (unsigned count = 1; count < 3; count++) {
+        lexer->mark_end(lexer);
+        for (unsigned count = 1; count < DELIMITER_LENGTH; ++count) {
           advance(lexer);
           if (lexer->lookahead != end_char) {
-            mark_end(lexer);
+            lexer->mark_end(lexer);
             lexer->result_symbol = STRING_CONTENT;
             return true;
           }
         }
 
-        /* This is so if we lex something like 
+        /* This is so if we lex something like
            """foo"""
-              ^ 
+              ^
            where we are at the `f`, we should quit after
            reading `foo`, and ascribe it to STRING_CONTENT.
 
@@ -177,29 +145,29 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack) {
         }
 
         /* Since the string internals are all hidden in the syntax
-           tree anyways, there's no point in going to the effort of 
+           tree anyways, there's no point in going to the effort of
            specifically separating the string end from string contents.
            If we see a bunch of quotes in a row, then we just go until
            they stop appearing, then stop lexing and call it the
            string's end.
          */
         lexer->result_symbol = STRING_END;
-        mark_end(lexer);
+        lexer->mark_end(lexer);
         while (lexer->lookahead == end_char) {
           advance(lexer);
-          mark_end(lexer);
+          lexer->mark_end(lexer);
         }
-        pop(stack);
+        stack_pop(stack);
         return true;
       }
       if (has_content) {
-        mark_end(lexer);
+        lexer->mark_end(lexer);
         lexer->result_symbol = STRING_CONTENT;
         return true;
       }
-      pop(stack);
+      stack_pop(stack);
       advance(lexer);
-      mark_end(lexer);
+      lexer->mark_end(lexer);
       lexer->result_symbol = STRING_END;
       return true;
     }
@@ -227,16 +195,16 @@ static bool scan_multiline_comment(TSLexer *lexer) {
         advance(lexer);
         if (after_star) {
           after_star = false;
-          nesting_depth--;
+          nesting_depth -= 1;
           if (nesting_depth == 0) {
             lexer->result_symbol = MULTILINE_COMMENT;
-            mark_end(lexer);
+            lexer->mark_end(lexer);
             return true;
           }
         } else {
           after_star = false;
           if (lexer->lookahead == '*') {
-            nesting_depth++;
+            nesting_depth += 1;
             advance(lexer);
           }
         }
@@ -252,21 +220,13 @@ static bool scan_multiline_comment(TSLexer *lexer) {
 }
 
 static bool scan_whitespace_and_comments(TSLexer *lexer) {
-  for (;;) {
-    while (iswspace(lexer->lookahead)) {
-      skip(lexer);
-    }
-
-    if (lexer->lookahead == '/') {
-      return false;
-    }
-    return true;
-  }
+  while (iswspace(lexer->lookahead)) skip(lexer);
+  return lexer->lookahead != '/';
 }
 
 static bool scan_for_word(TSLexer *lexer, const char* word, unsigned len) {
     skip(lexer);
-    for (unsigned i = 0; i < len; i++) {
+    for (unsigned i = 0; i < len; ++i) {
       if (lexer->lookahead != word[i]) return false;
       skip(lexer);
     }
@@ -279,8 +239,7 @@ static bool scan_automatic_semicolon(TSLexer *lexer) {
 
   bool sameline = true;
   for (;;) {
-    if (lexer->eof(lexer))
-      return true;
+    if (lexer->eof(lexer)) return true;
 
     if (lexer->lookahead == ';') {
       advance(lexer);
@@ -288,13 +247,10 @@ static bool scan_automatic_semicolon(TSLexer *lexer) {
       return true;
     }
 
-    if (!iswspace(lexer->lookahead)) {
-      break;
-    }
+    if (!iswspace(lexer->lookahead)) break;
 
     if (lexer->lookahead == '\n') {
       skip(lexer);
-
       sameline = false;
       break;
     }
@@ -302,9 +258,7 @@ static bool scan_automatic_semicolon(TSLexer *lexer) {
     if (lexer->lookahead == '\r') {
       skip(lexer);
 
-      if (lexer->lookahead == '\n') {
-        skip(lexer);
-      }
+      if (lexer->lookahead == '\n') skip(lexer);
 
       sameline = false;
       break;
@@ -353,18 +307,17 @@ static bool scan_automatic_semicolon(TSLexer *lexer) {
     case '&':
     case '/':
       return false;
-    
+
     // Insert a semicolon before `--` and `++`, but not before binary `+` or `-`.
     // Insert before +/-Float
     case '+':
       skip(lexer);
-      if (lexer->lookahead == '+')
-        return true;
+      if (lexer->lookahead == '+') return true;
       return iswdigit(lexer->lookahead);
+
     case '-':
       skip(lexer);
-      if (lexer->lookahead == '-')
-        return true;
+      if (lexer->lookahead == '-') return true;
       return iswdigit(lexer->lookahead);
 
     // Don't insert a semicolon before `!=`, but do insert one before a unary `!`.
@@ -380,19 +333,15 @@ static bool scan_automatic_semicolon(TSLexer *lexer) {
     // before an identifier or an import.
     case 'i':
       skip(lexer);
-      if (lexer->lookahead != 'n')
-        return true;
-
+      if (lexer->lookahead != 'n') return true;
       skip(lexer);
-      if (!iswalpha(lexer->lookahead))
-        return false;
-
+      if (!iswalpha(lexer->lookahead)) return false;
       return !scan_for_word(lexer, "stanceof", 8);
 
-      case ';':
-        advance(lexer);
-        lexer->mark_end(lexer);
-        return true;
+    case ';':
+      advance(lexer);
+      lexer->mark_end(lexer);
+      return true;
 
     default:
       return true;
@@ -497,36 +446,30 @@ static bool scan_import_list_delimiter(TSLexer *lexer) {
   }
 }
 
-bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
-                                                  const bool *valid_symbols) {
-
-  bool *in_string = payload;
-
+bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
   if (valid_symbols[AUTOMATIC_SEMICOLON]) {
     bool ret = scan_automatic_semicolon(lexer);
-    if (!ret && valid_symbols[SAFE_NAV] && lexer->lookahead == '?')
+    if (!ret && valid_symbols[SAFE_NAV] && lexer->lookahead == '?') {
       return scan_safe_nav(lexer);
+    }
 
-    // if we fail to find an automatic semicolon, it's still possible that we may 
+    // if we fail to find an automatic semicolon, it's still possible that we may
     // want to lex a string or comment later
-    if (ret)
-      return ret;
+    if (ret) return ret;
   }
 
-  if (valid_symbols[IMPORT_LIST_DELIMITER])
+  if (valid_symbols[IMPORT_LIST_DELIMITER]) {
     return scan_import_list_delimiter(lexer);
+  }
 
   // content or end
-  if (valid_symbols[STRING_CONTENT] &&
-      scan_string_content(lexer, payload)) {
+  if (valid_symbols[STRING_CONTENT] && scan_string_content(lexer, payload)) {
     return true;
   }
 
-  // a string might follow after some whitespace, so we can't lookahead 
+  // a string might follow after some whitespace, so we can't lookahead
   // until we get rid of it
-  while(iswspace(lexer->lookahead)) {
-    skip(lexer);
-  }
+  while (iswspace(lexer->lookahead)) skip(lexer);
 
   if (valid_symbols[STRING_START] && scan_string_start(lexer, payload)) {
     lexer->result_symbol = STRING_START;
@@ -544,23 +487,31 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer,
   return false;
 }
 
-void *tree_sitter_kotlin_external_scanner_create() { return new_stack(); }
+void *tree_sitter_kotlin_external_scanner_create() {
+  Stack *stack = ts_calloc(1, sizeof(Stack));
+  if (stack == NULL) abort();
+  array_init(stack);
+  return stack;
+}
 
 void tree_sitter_kotlin_external_scanner_destroy(void *payload) {
-  free_stack(payload);
+  Stack *stack = (Stack *)payload;
+  array_delete(stack);
+  ts_free(stack);
 }
 
-unsigned tree_sitter_kotlin_external_scanner_serialize(
-    void *payload,
-    char *buffer
-) {
-  return serialize_stack(payload, buffer);
+unsigned tree_sitter_kotlin_external_scanner_serialize(void *payload, char *buffer) {
+  Stack *stack = (Stack *)payload;
+  memcpy(buffer, stack->contents, stack->size);
+  return stack->size;
 }
 
-void tree_sitter_kotlin_external_scanner_deserialize(
-    void *payload,
-    const char *buffer,
-    unsigned length
-) {
-  deserialize_stack(payload, buffer, length);
+void tree_sitter_kotlin_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+  Stack *stack = (Stack *)payload;
+  if (length > 0) {
+    memcpy(stack->contents, buffer, length);
+    stack->size = length;
+  } else {
+    array_clear(stack);
+  }
 }


### PR DESCRIPTION
- Use local import for `parser.h`
- Use the new built-in array API
- Define `DELIMITER_LENGTH` constant
- Mark simple functions as `inline`
- Remove functions that are only used once
- Remove rarely used `mark_end` function
- Simplify `scan_whitespace_and_comments` function
- Use bitwise and instead of modulo
- Various codestyle improvements