### PR TITLE
Add star-import nonterminal to retain '.*' in the parse tree

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -168,11 +168,13 @@ module.exports = grammar({
     import_header: $ => seq(
       "import",
       $.identifier,
-      optional(choice(seq(".*"), $.import_alias)),
+      optional(choice($.star_import, $.import_alias)),
       $._semi
     ),
 
-    import_alias: $ => seq("as", alias($.simple_identifier, $.type_identifier)),
+    star_import: $ => seq(".*"),
+
+    import_alias: $ => seq("as", $.simple_identifier),
 
     top_level_object: $ => seq($._declaration, optional($._semi)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -118,7 +118,7 @@ module.exports = grammar({
     $.multiline_comment,
     $._string_start,
     $._string_end,
-    $._string_content,
+    $.string_content,
   ],
 
   extras: $ => [
@@ -762,7 +762,7 @@ module.exports = grammar({
 
     string_literal: $ => seq(
       $._string_start,
-      repeat(choice($._string_content, $._interpolation)),
+      repeat(choice($.string_content, $._interpolation)),
       $._string_end,
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -175,13 +175,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ".*"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "star_import"
                 },
                 {
                   "type": "SYMBOL",
@@ -200,6 +195,15 @@
         }
       ]
     },
+    "star_import": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ".*"
+        }
+      ]
+    },
     "import_alias": {
       "type": "SEQ",
       "members": [
@@ -208,13 +212,8 @@
           "value": "as"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "simple_identifier"
-          },
-          "named": true,
-          "value": "type_identifier"
+          "type": "SYMBOL",
+          "name": "simple_identifier"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3818,7 +3818,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_string_content"
+                "name": "string_content"
               },
               {
                 "type": "SYMBOL",
@@ -6335,7 +6335,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_string_content"
+      "name": "string_content"
     }
   ],
   "inline": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4209,7 +4209,7 @@
       "required": true,
       "types": [
         {
-          "type": "type_identifier",
+          "type": "simple_identifier",
           "named": true
         }
       ]
@@ -4229,6 +4229,10 @@
         },
         {
           "type": "import_alias",
+          "named": true
+        },
+        {
+          "type": "star_import",
           "named": true
         }
       ]
@@ -7589,6 +7593,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "star_import",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "statements",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7824,6 +7824,10 @@
         {
           "type": "interpolated_identifier",
           "named": true
+        },
+        {
+          "type": "string_content",
+          "named": true
         }
       ]
     }
@@ -9523,6 +9527,10 @@
   {
     "type": "setparam",
     "named": false
+  },
+  {
+    "type": "string_content",
+    "named": true
   },
   {
     "type": "super",

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -66,9 +66,12 @@ extern "C" {
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
 #define array_grow_by(self, count) \
-  (_array__grow((Array *)(self), count, array_elem_size(self)), \
-   memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)), \
-   (self)->size += (count))
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
 
 /// Append all elements from one array to the end of another.
 #define array_push_all(self, other)                                       \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -86,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -125,6 +130,24 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
@@ -152,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -203,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -64,4 +64,4 @@ fun main(){
             (simple_identifier)
             (indexing_suffix
               (integer_literal)))
-          (string_literal))))))
+          (string_literal (string_content)))))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -75,16 +75,16 @@ class Strings {
        (simple_identifier)
        (function_value_parameters)
        (function_body
-        (string_literal)))
+        (string_literal (string_content))))
       (function_declaration
        (simple_identifier)
        (function_value_parameters)
        (function_body
         (additive_expression
           (additive_expression
-              (string_literal)
-              (string_literal))
-            (string_literal)))))))
+              (string_literal (string_content))
+              (string_literal (string_content)))
+            (string_literal (string_content))))))))
 
 ================================================================================
 Class with modifiers

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -76,7 +76,7 @@ sum(1, 2)
     (call_suffix
       (value_arguments
         (value_argument
-          (string_literal)))))
+          (string_literal (string_content))))))
   (call_expression
     (simple_identifier)
     (call_suffix
@@ -162,7 +162,7 @@ val MyDate.s: String get() = "hello"
         (type_identifier)))
     (getter
       (function_body
-        (string_literal)))))
+        (string_literal (string_content))))))
 
 ================================================================================
 Expect as an expression
@@ -429,7 +429,7 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -438,7 +438,7 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -447,7 +447,7 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -456,15 +456,15 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
-    (string_literal))
+    (string_literal (string_content)))
   (property_declaration
     (variable_declaration
       (simple_identifier))
-    (string_literal)))
+    (string_literal (string_content))))
 
 ================================================================================
 Qualified this/super expressions

--- a/test/corpus/imports.txt
+++ b/test/corpus/imports.txt
@@ -1,0 +1,64 @@
+==================
+simple import
+==================
+
+import pkg
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)))))
+
+==================
+qualified import
+==================
+
+import a.b.c
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier)
+        (simple_identifier)))))
+
+==================
+import alias
+==================
+
+import a.b.c as x
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier)
+        (simple_identifier))
+      (import_alias
+        (simple_identifier)))))
+
+==================
+star import
+==================
+
+import a.b.c.*
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier)
+        (simple_identifier))
+      (star_import))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -46,8 +46,12 @@ string.
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal)
-  (string_literal))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)))
 
 ================================================================================
 String literal with lots of repeated quotes
@@ -59,7 +63,15 @@ There's a lot of ""quotations"". Even at the "end""""
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal))
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)))
 
 ================================================================================
 String interpolation
@@ -76,14 +88,23 @@ ${"""string interpolation"""} $literal
 
 (source_file
   (string_literal
-    (interpolated_identifier))
+    (string_content)
+    (interpolated_identifier)
+    (string_content))
   (string_literal
+    (string_content)
     (interpolated_expression
-      (string_literal)))
+      (string_literal
+        (string_content)))
+    (string_content))
   (string_literal
+    (string_content)
     (interpolated_expression
-      (string_literal))
-    (interpolated_identifier)))
+      (string_literal
+        (string_content)))
+    (string_content)
+    (interpolated_identifier)
+    (string_content)))
 
 ================================================================================
 More string interpolation
@@ -97,10 +118,19 @@ More string interpolation
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal)
-  (string_literal)
-  (string_literal)
-  (string_literal))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content)
+    (string_content))
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content))
+  (string_literal
+    (string_content)))
 
 ================================================================================
 Integer literals
@@ -154,11 +184,11 @@ assertEquals("\u214E\uA7B5\u2CEF", "\u2132\uA7B4\u2CEF".lowercase())
     (call_suffix
       (value_arguments
         (value_argument
-          (string_literal))
+          (string_literal (string_content)))
         (value_argument
           (call_expression
             (navigation_expression
-              (string_literal)
+              (string_literal (string_content))
               (navigation_suffix
                 (simple_identifier)))
             (call_suffix

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -78,7 +78,7 @@ fun foo():String
     (function_body
       (statements
         (jump_expression
-          (string_literal))))))
+          (string_literal (string_content)))))))
 
 ================================================================================
 Colon after newline

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -15,7 +15,7 @@ val x = 4
         (type_identifier))
       (value_arguments
         (value_argument
-          (string_literal)))))
+          (string_literal (string_content))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -41,7 +41,7 @@ Multiple file annotations
         (type_identifier))
       (value_arguments
         (value_argument
-          (string_literal)))))
+          (string_literal (string_content))))))
   (file_annotation
     (constructor_invocation
       (user_type

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -228,10 +228,10 @@ a as Foo(x = "hi", y = "bar")
       (value_arguments
         (value_argument
           (simple_identifier)
-          (string_literal))
+          (string_literal (string_content)))
         (value_argument
           (simple_identifier)
-          (string_literal))))))
+          (string_literal (string_content)))))))
 
 ================================================================================
 Type constructor with trailing comma
@@ -251,10 +251,10 @@ a as Foo(x = "hi", y = "bar",)
       (value_arguments
         (value_argument
           (simple_identifier)
-          (string_literal))
+          (string_literal (string_content)))
         (value_argument
           (simple_identifier)
-          (string_literal))))))
+          (string_literal (string_content)))))))
 
 ================================================================================
 Type alias with type parameters


### PR DESCRIPTION
Currently, it is not possible to distinguish star imports in the parse tree because `.*` is not retained. This PR exposes the `star_import` nonterminal to retain this information in the parse tree.