### PR TITLE
Expose null_literal as a node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -755,7 +755,7 @@ module.exports = grammar({
       $.bin_literal,
       $.character_literal,
       $.real_literal,
-      "null",
+      $.null_literal,
       $.long_literal,
       $.unsigned_literal
     ),
@@ -1195,6 +1195,10 @@ module.exports = grammar({
     character_escape_seq: $ => choice(
       $._uni_character_literal,
       $._escaped_identifier
+    ),
+
+    null_literal: $ => seq(
+      "null"
     ),
 
     // ==========

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3791,8 +3791,8 @@
           "name": "real_literal"
         },
         {
-          "type": "STRING",
-          "value": "null"
+          "type": "SYMBOL",
+          "name": "null_literal"
         },
         {
           "type": "SYMBOL",
@@ -6145,6 +6145,15 @@
         {
           "type": "SYMBOL",
           "name": "_escaped_identifier"
+        }
+      ]
+    },
+    "null_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "null"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5,7 +5,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -105,6 +105,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -284,7 +288,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -392,6 +396,10 @@
         },
         {
           "type": "not_nullable_type",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -582,6 +590,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -758,6 +770,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -931,7 +947,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -1039,6 +1055,10 @@
         },
         {
           "type": "not_nullable_type",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -1336,6 +1356,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "nullable_type",
           "named": true
         },
@@ -1519,6 +1543,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -1610,7 +1638,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -1710,6 +1738,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -1877,6 +1909,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -2113,6 +2149,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_declaration",
           "named": true
         },
@@ -2228,7 +2268,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "anonymous_function",
@@ -2284,6 +2324,10 @@
         },
         {
           "type": "navigation_suffix",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -2435,6 +2479,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -2609,6 +2657,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -2776,6 +2828,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -2922,7 +2978,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -3022,6 +3078,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -3193,6 +3253,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -3413,6 +3477,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -3581,6 +3649,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -3905,6 +3977,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -4142,6 +4218,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -4362,6 +4442,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -4526,6 +4610,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -4696,6 +4784,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -4765,7 +4857,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -4865,6 +4957,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -5041,6 +5137,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -5241,7 +5341,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -5341,6 +5441,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -5515,6 +5619,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -5614,6 +5722,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "null_literal",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "nullable_type",
@@ -5910,6 +6023,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -6033,7 +6150,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -6136,6 +6253,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -6200,7 +6321,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -6308,6 +6429,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -6506,6 +6631,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -6712,6 +6841,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -6879,6 +7012,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -6943,7 +7080,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "additive_expression",
@@ -7043,6 +7180,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -7337,6 +7478,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_declaration",
           "named": true
         },
@@ -7529,6 +7674,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -7728,6 +7877,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {
@@ -8375,6 +8528,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -8606,6 +8763,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -8823,6 +8984,10 @@
           "named": true
         },
         {
+          "type": "null_literal",
+          "named": true
+        },
+        {
           "type": "object_literal",
           "named": true
         },
@@ -8995,6 +9160,10 @@
         },
         {
           "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
           "named": true
         },
         {

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -66,9 +66,12 @@ extern "C" {
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
 #define array_grow_by(self, count) \
-  (_array__grow((Array *)(self), count, array_elem_size(self)), \
-   memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)), \
-   (self)->size += (count))
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
 
 /// Append all elements from one array to the end of another.
 #define array_push_all(self, other)                                       \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -86,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -125,6 +130,24 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
@@ -152,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -203,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -18,7 +18,8 @@ class Foo(){
     (class_body
       (property_declaration
         (variable_declaration
-          (simple_identifier)))
+          (simple_identifier))
+        (null_literal))
       (secondary_constructor
       (function_value_parameters
         (parameter

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -142,7 +142,8 @@ when (this) {
             (type_arguments
               (type_projection)))))
       (control_structure_body
-        (jump_expression)))))
+        (jump_expression
+          (null_literal))))))
 
 ================================================================================
 Value declaration with receiver type

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -304,3 +304,17 @@ fun `this is a test function`() = true
    (simple_identifier)
    (function_value_parameters)
    (function_body (boolean_literal))))
+
+==================
+Function with null literal as expression body
+==================
+
+fun f() = null
+
+---
+
+(source_file
+  (function_declaration
+   (simple_identifier)
+   (function_value_parameters)
+   (function_body (null_literal))))


### PR DESCRIPTION
We need to expose null literals in parse trees, otherwise, it will not be possible to syntactically differentiate between some constructs. 
Example: currently, these two functions yield the same parse tree:
```
fun f() = null
fun f() { }
```
```
source_file
  function_declaration
    simple_identifier
    function_value_parameters
    function_body
```

With the changes in this PR, the first function will have a `null_literal` in the tree:
```
source_file
  function_declaration
    simple_identifier
    function_value_parameters
    function_body
      null_literal
```