### PR TITLE
feat(grammar): Expose wildcard imports as named nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -167,10 +167,12 @@ module.exports = grammar({
 
     import_header: $ => seq(
       "import",
-      $.identifier,
-      optional(choice(seq(".*"), $.import_alias)),
+      alias($._import_identifier, $.identifier),
+      optional(choice(seq(".", $.wildcard_import), $.import_alias)),
       $._semi
     ),
+
+    wildcard_import: _ => token.immediate("*"),
 
     import_alias: $ => seq("as", alias($.simple_identifier, $.type_identifier)),
 
@@ -1098,6 +1100,13 @@ module.exports = grammar({
     ),
 
     identifier: $ => sep1($.simple_identifier, "."),
+
+    // Adapted from tree-sitter-java, helps to avoid a conflic with
+    // wildcard_import node while being compatible with identifier
+    _import_identifier: $ => choice(
+      $.simple_identifier,
+      seq($._import_identifier, ".", $.simple_identifier),
+    ),
 
     // ====================
     // Lexical grammar

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -165,8 +165,13 @@
           "value": "import"
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_import_identifier"
+          },
+          "named": true,
+          "value": "identifier"
         },
         {
           "type": "CHOICE",
@@ -179,7 +184,11 @@
                   "members": [
                     {
                       "type": "STRING",
-                      "value": ".*"
+                      "value": "."
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "wildcard_import"
                     }
                   ]
                 },
@@ -199,6 +208,13 @@
           "name": "_semi"
         }
       ]
+    },
+    "wildcard_import": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "STRING",
+        "value": "*"
+      }
     },
     "import_alias": {
       "type": "SEQ",
@@ -5460,6 +5476,32 @@
               }
             ]
           }
+        }
+      ]
+    },
+    "_import_identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "simple_identifier"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_import_identifier"
+            },
+            {
+              "type": "STRING",
+              "value": "."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "simple_identifier"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4230,6 +4230,10 @@
         {
           "type": "import_alias",
           "named": true
+        },
+        {
+          "type": "wildcard_import",
+          "named": true
         }
       ]
     }
@@ -9165,10 +9169,6 @@
     "named": false
   },
   {
-    "type": ".*",
-    "named": false
-  },
-  {
     "type": "..",
     "named": false
   },
@@ -9591,6 +9591,10 @@
   {
     "type": "while",
     "named": false
+  },
+  {
+    "type": "wildcard_import",
+    "named": true
   },
   {
     "type": "{",

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -66,9 +66,12 @@ extern "C" {
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
 #define array_grow_by(self, count) \
-  (_array__grow((Array *)(self), count, array_elem_size(self)), \
-   memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)), \
-   (self)->size += (count))
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
 
 /// Append all elements from one array to the end of another.
 #define array_push_all(self, other)                                       \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -86,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -125,6 +130,24 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
@@ -152,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -203,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -55,6 +55,7 @@ Multiple file annotations
 Imports
 ================================================================================
 
+import java.util.*
 import java.util.Scanner
 import java.util.StringBuilder
 
@@ -67,6 +68,11 @@ fun main() {
 
 (source_file
   (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier))
+      (wildcard_import))
     (import_header
       (identifier
         (simple_identifier)


### PR DESCRIPTION
Parse "." and "*" for wildcard imports as separate nodes, allowing them to be more precisely highlighted.
Create a new named node `wildcard_import`.