### PR TITLE
Update `build-wasm` script and add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "install": "node-gyp-build",
     "generate": "tree-sitter generate",
     "parse": "tree-sitter parse",
-    "build-wasm": "tree-sitter build-wasm",
+    "build-wasm": "tree-sitter build --wasm",
     "playground": "tree-sitter playground",
+    "prestart": "npm run build-wasm",
+    "start": "npm run playground",
     "prebuildify": "prebuildify --napi --strip"
   },
   "repository": {


### PR DESCRIPTION
This migrates the deprecated `tree-sitter build-wasm` script to `tree-sitter build --wasm`. It also adds a `start` script that automatically builds the Wasm binary before launching the playground for convenience.