### PR TITLE
Fix seg fault in scanner.c: Allocate the stack array if null

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -521,9 +521,7 @@ unsigned tree_sitter_kotlin_external_scanner_serialize(void *payload, char *buff
 void tree_sitter_kotlin_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
   Stack *stack = (Stack *)payload;
   if (length > 0) {
-    if (!stack->contents) {
-      stack->contents = malloc(length);
-    }
+    array_reserve(stack, length);
     memcpy(stack->contents, buffer, length);
     stack->size = length;
   } else {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -521,6 +521,9 @@ unsigned tree_sitter_kotlin_external_scanner_serialize(void *payload, char *buff
 void tree_sitter_kotlin_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
   Stack *stack = (Stack *)payload;
   if (length > 0) {
+    if (!stack->contents) {
+      stack->contents = malloc(length);
+    }
     memcpy(stack->contents, buffer, length);
     stack->size = length;
   } else {


### PR DESCRIPTION
https://github.com/fwcd/tree-sitter-kotlin/pull/115 introduces a segfault in the following function in `scanner.c`. I noticed 
`(signal: 11, SIGSEGV: invalid memory reference` in some of our tests after upgrading.

```
void tree_sitter_kotlin_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
  Stack *stack = (Stack *)payload;
  if (length > 0) {
    memcpy(stack->contents, buffer, length); // <<< stack.contents can be null
    stack->size = length;
  } else {
    array_clear(stack);
  }
}
```

This PR fixes the segfault by adding a null check here.