### PR TITLE
Fixed Go binding

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-kotlin"
+	tree_sitter_kotlin "github.com/fwcd/tree-sitter-kotlin/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter/tree-sitter-kotlin
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/fwcd/tree-sitter-kotlin
+
+go 1.22
+
+require github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82


### PR DESCRIPTION
The Go module wasn't working for this grammar. The problem was in the directory where the `go.mod` file was located, and the module name; now, it's working and passing test.