### PR TITLE
Do not memcpy from empty source

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -514,6 +514,9 @@ void tree_sitter_kotlin_external_scanner_destroy(void *payload) {
 
 unsigned tree_sitter_kotlin_external_scanner_serialize(void *payload, char *buffer) {
   Stack *stack = (Stack *)payload;
+  if (stack->size == 0) {
+    return 0;
+  }
   memcpy(buffer, stack->contents, stack->size);
   return stack->size;
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -514,10 +514,10 @@ void tree_sitter_kotlin_external_scanner_destroy(void *payload) {
 
 unsigned tree_sitter_kotlin_external_scanner_serialize(void *payload, char *buffer) {
   Stack *stack = (Stack *)payload;
-  if (stack->size == 0) {
-    return 0;
+  if (stack->size > 0) {
+    // it's an undefined behavior to memcpy 0 bytes
+    memcpy(buffer, stack->contents, stack->size);
   }
-  memcpy(buffer, stack->contents, stack->size);
   return stack->size;
 }
 


### PR DESCRIPTION
memcpy(dst, src, size) is a Undefined behavior if src is nullptr, even if size is 0. (https://en.cppreference.com/w/c/string/byte/memcpy)
I ran into a case where the input Stack parameter for the scanner serialize call has the has NULL content, 0 size and 0 capacity. And that caused runtime crash when build with UBSAN.

I thought about checking src being nullptr instead of size being 0. But I think if we ever get an input where src is nullptr but size > 0, that's bug somewhere else and we should crash program to surface that. Nullptr + zero size sounds relatively legit to actually hit this function, we just shouldn't try to do memcpy with such empty src. Thus i went with checking the size, not the src ptr. Let me know if people prefer other way. Thanks.