### PR TITLE
Improve handling of receiver types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To run the unit tests, run:
 
 >`npm run test`
 
+It is also helpful to run the parser on a real Kotlin project's source files.
+
+```shell
+./node_modules/.bin/tree-sitter parse "/path/to/some/project/**/*.kt"  --quiet --stat
+```
+
 ## WebAssembly
 
 ### Compilation

--- a/grammar.js
+++ b/grammar.js
@@ -94,7 +94,7 @@ module.exports = grammar({
     // ambiguity between multiple user types and class property/function declarations
     [$.user_type],
     [$.user_type, $.anonymous_function],
-    [$.user_type, $.function_type],
+    //[$.user_type, $.function_type],
 
     // ambiguity between annotated_lambda with modifiers and modifiers from var declarations
     [$.annotated_lambda, $.modifiers],
@@ -110,6 +110,9 @@ module.exports = grammar({
     [$.type_modifiers],
     // ambiguity between associating type modifiers
     [$.not_nullable_type],
+
+    [$._receiver_type],
+    [$._receiver_type, $._type],
   ],
 
   externals: $ => [
@@ -340,9 +343,9 @@ module.exports = grammar({
     _receiver_type: $ => seq(
       optional($.type_modifiers),
       choice (
-        $._type_reference,
         $.parenthesized_type,
-        $.nullable_type
+        $.nullable_type,
+        $._type_reference,
       )
     ),
 
@@ -464,10 +467,10 @@ module.exports = grammar({
     _type: $ => seq(
       optional($.type_modifiers),
       choice(
+        $.function_type,
         $.parenthesized_type,
         $.nullable_type,
         $._type_reference,
-        $.function_type,
         $.not_nullable_type
       )
     ),
@@ -513,7 +516,8 @@ module.exports = grammar({
     _type_projection_modifier: $ => $.variance_modifier,
 
     function_type: $ => seq(
-      optional(seq($._simple_user_type, ".")), // TODO: Support "real" types
+      // TODO: [receiverType {NL} '.' {NL}] functionTypeParameters {NL}  '->' {NL} type
+      optional(seq($._receiver_type, ".")), // TODO: Support "real" types
       $.function_type_parameters,
       "->",
       $._type

--- a/grammar.js
+++ b/grammar.js
@@ -751,7 +751,13 @@ module.exports = grammar({
 
     parenthesized_expression: $ => seq("(", $._expression, ")"),
 
-    collection_literal: $ => seq("[", $._expression, repeat(seq(",", $._expression)), "]"),
+    // https://kotlinlang.org/spec/syntax-and-grammar.html#grammar-rule-collectionLiteral
+    collection_literal: $ => seq(
+      "[",
+      $._expression,
+      repeat(seq(",", $._expression)),
+      optional(","),
+      "]"),
 
     _literal_constant: $ => choice(
       $.boolean_literal,
@@ -836,7 +842,7 @@ module.exports = grammar({
         seq(
           optional(field('consequence', $.control_structure_body)),
           optional(";"),
-          "else", 
+          "else",
           choice(field('alternative', $.control_structure_body), ";")
         ),
         ";"

--- a/grammar.js
+++ b/grammar.js
@@ -111,8 +111,8 @@ module.exports = grammar({
     // ambiguity between associating type modifiers
     [$.not_nullable_type],
 
-    [$._receiver_type],
-    [$._receiver_type, $._type],
+    [$.receiver_type],
+    [$.receiver_type, $._type],
   ],
 
   externals: $ => [
@@ -340,7 +340,7 @@ module.exports = grammar({
       optional(seq("=", $._expression))
     ),
 
-    _receiver_type: $ => seq(
+    receiver_type: $ => seq(
       optional($.type_modifiers),
       choice (
         $.parenthesized_type,
@@ -353,7 +353,7 @@ module.exports = grammar({
       optional($.modifiers),
       "fun",
       optional($.type_parameters),
-      optional(seq($._receiver_type, optional('.'))),
+      optional(seq(field("receiver", $.receiver_type), optional('.'))),
       $.simple_identifier,
       $.function_value_parameters,
       optional(seq(":", $._type)),
@@ -373,7 +373,7 @@ module.exports = grammar({
       optional($.modifiers),
       $.binding_pattern_kind,
       optional($.type_parameters),
-      optional(seq($._receiver_type, optional('.'))),
+      optional(seq(field("receiver", $.receiver_type), optional('.'))),
       choice($.variable_declaration, $.multi_variable_declaration),
       optional($.type_constraints),
       optional(choice(
@@ -516,8 +516,7 @@ module.exports = grammar({
     _type_projection_modifier: $ => $.variance_modifier,
 
     function_type: $ => seq(
-      // TODO: [receiverType {NL} '.' {NL}] functionTypeParameters {NL}  '->' {NL} type
-      optional(seq($._receiver_type, ".")), // TODO: Support "real" types
+      optional(seq(field("receiver", $.receiver_type), ".")),
       $.function_type_parameters,
       "->",
       $._type

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3773,6 +3773,18 @@
           }
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "]"
         }
@@ -6390,3 +6402,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1240,7 +1240,7 @@
         }
       ]
     },
-    "_receiver_type": {
+    "receiver_type": {
       "type": "SEQ",
       "members": [
         {
@@ -1260,15 +1260,15 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_type_reference"
-            },
-            {
-              "type": "SYMBOL",
               "name": "parenthesized_type"
             },
             {
               "type": "SYMBOL",
               "name": "nullable_type"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_type_reference"
             }
           ]
         }
@@ -1315,8 +1315,12 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "_receiver_type"
+                    "type": "FIELD",
+                    "name": "receiver",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "receiver_type"
+                    }
                   },
                   {
                     "type": "CHOICE",
@@ -1490,8 +1494,12 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "_receiver_type"
+                    "type": "FIELD",
+                    "name": "receiver",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "receiver_type"
+                    }
                   },
                   {
                     "type": "CHOICE",
@@ -2175,6 +2183,10 @@
           "members": [
             {
               "type": "SYMBOL",
+              "name": "function_type"
+            },
+            {
+              "type": "SYMBOL",
               "name": "parenthesized_type"
             },
             {
@@ -2184,10 +2196,6 @@
             {
               "type": "SYMBOL",
               "name": "_type_reference"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "function_type"
             },
             {
               "type": "SYMBOL",
@@ -2408,8 +2416,12 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "_simple_user_type"
+                  "type": "FIELD",
+                  "name": "receiver",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "receiver_type"
+                  }
                 },
                 {
                   "type": "STRING",
@@ -6342,10 +6354,6 @@
       "anonymous_function"
     ],
     [
-      "user_type",
-      "function_type"
-    ],
-    [
       "annotated_lambda",
       "modifiers"
     ],
@@ -6366,6 +6374,13 @@
     ],
     [
       "not_nullable_type"
+    ],
+    [
+      "receiver_type"
+    ],
+    [
+      "receiver_type",
+      "_type"
     ]
   ],
   "precedences": [],
@@ -6402,4 +6417,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3730,7 +3730,18 @@
   {
     "type": "function_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "receiver": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "receiver_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -3794,7 +3805,18 @@
   {
     "type": "function_type",
     "named": true,
-    "fields": {},
+    "fields": {
+      "receiver": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "receiver_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -3817,14 +3839,6 @@
         },
         {
           "type": "parenthesized_type",
-          "named": true
-        },
-        {
-          "type": "type_arguments",
-          "named": true
-        },
-        {
-          "type": "type_identifier",
           "named": true
         },
         {
@@ -6541,7 +6555,18 @@
   {
     "type": "property_declaration",
     "named": true,
-    "fields": {},
+    "fields": {
+      "receiver": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "receiver_type",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": true,
       "required": true,
@@ -6667,19 +6692,11 @@
           "named": true
         },
         {
-          "type": "nullable_type",
-          "named": true
-        },
-        {
           "type": "object_literal",
           "named": true
         },
         {
           "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "parenthesized_type",
           "named": true
         },
         {
@@ -6735,19 +6752,11 @@
           "named": true
         },
         {
-          "type": "type_modifiers",
-          "named": true
-        },
-        {
           "type": "type_parameters",
           "named": true
         },
         {
           "type": "unsigned_literal",
-          "named": true
-        },
-        {
-          "type": "user_type",
           "named": true
         },
         {
@@ -7269,6 +7278,33 @@
         },
         {
           "type": "when_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "receiver_type",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "nullable_type",
+          "named": true
+        },
+        {
+          "type": "parenthesized_type",
+          "named": true
+        },
+        {
+          "type": "type_modifiers",
+          "named": true
+        },
+        {
+          "type": "user_type",
           "named": true
         }
       ]

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -87,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -126,13 +130,38 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -146,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -166,7 +206,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +216,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +224,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}
@@ -197,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -86,11 +87,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,38 +126,13 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -175,17 +146,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -206,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -216,7 +176,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -224,7 +184,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}
@@ -237,15 +197,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -124,3 +124,50 @@ fun foo() = bar {}
             (lambda_literal)))))))
 
 
+==================
+Comma in annotation property
+==================
+
+class EnvironmentSpec {
+    @Option(
+      names = ["--environment", "--env"],
+      arity = "0..1",
+      description = [
+          "Which environment to use",
+      ],
+    )
+    var environment: Environment
+}
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (modifiers
+          (annotation
+            (constructor_invocation
+              (user_type
+                (type_identifier))
+              (value_arguments
+                (value_argument
+                  (simple_identifier)
+                  (collection_literal
+                    (string_literal (string_content))
+                    (string_literal (string_content))))
+                (value_argument
+                  (simple_identifier)
+                  (string_literal (string_content)))
+                (value_argument
+                  (simple_identifier)
+                  (collection_literal
+                    (string_literal (string_content))
+                  ))))))
+        (binding_pattern_kind)
+        (variable_declaration
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+      ))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -76,7 +76,8 @@ sum(1, 2)
     (call_suffix
       (value_arguments
         (value_argument
-          (string_literal (string_content))))))
+          (string_literal
+            (string_content))))))
   (call_expression
     (simple_identifier)
     (call_suffix
@@ -158,15 +159,17 @@ val MyDate.s: String get() = "hello"
 (source_file
   (property_declaration
     (binding_pattern_kind)
-    (user_type
-      (type_identifier))
+    (receiver_type
+      (user_type
+        (type_identifier)))
     (variable_declaration
       (simple_identifier)
       (user_type
         (type_identifier)))
     (getter
       (function_body
-        (string_literal (string_content))))))
+        (string_literal
+          (string_content))))))
 
 ================================================================================
 Expect as an expression
@@ -462,7 +465,8 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal (string_content)))))))
+            (string_literal
+              (string_content)))))))
   (property_declaration
     (binding_pattern_kind)
     (variable_declaration
@@ -472,7 +476,8 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal (string_content)))))))
+            (string_literal
+              (string_content)))))))
   (property_declaration
     (binding_pattern_kind)
     (variable_declaration
@@ -482,7 +487,8 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal (string_content)))))))
+            (string_literal
+              (string_content)))))))
   (property_declaration
     (binding_pattern_kind)
     (variable_declaration
@@ -492,17 +498,20 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal (string_content)))))))
+            (string_literal
+              (string_content)))))))
   (property_declaration
     (binding_pattern_kind)
     (variable_declaration
       (simple_identifier))
-    (string_literal (string_content)))
+    (string_literal
+      (string_content)))
   (property_declaration
     (binding_pattern_kind)
     (variable_declaration
       (simple_identifier))
-    (string_literal (string_content))))
+    (string_literal
+      (string_content))))
 
 ================================================================================
 Qualified this/super expressions
@@ -601,26 +610,24 @@ if (cond1) {
               (value_argument
                 (string_literal
                   (string_content))))))))
-    alternative:
-      (control_structure_body
-        (if_expression
-          condition: (simple_identifier)
-          consequence: (control_structure_body
-            (statements
-              (call_expression
-                (simple_identifier)
-                (call_suffix
-                  (value_arguments
-                    (value_argument
-                      (string_literal
-                        (string_content))))))))
-          alternative:
-            (control_structure_body
-              (statements
-                (call_expression
-                  (simple_identifier)
-                  (call_suffix
-                    (value_arguments
-                      (value_argument
-                        (string_literal
-                          (string_content))))))))))))
+    alternative: (control_structure_body
+      (if_expression
+        condition: (simple_identifier)
+        consequence: (control_structure_body
+          (statements
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (string_literal
+                      (string_content))))))))
+        alternative: (control_structure_body
+          (statements
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments
+                  (value_argument
+                    (string_literal
+                      (string_content))))))))))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -58,8 +58,9 @@ val ty x get () = 3
         (integer_literal))))
   (property_declaration
     (binding_pattern_kind)
-    (user_type
-      (type_identifier))
+    (receiver_type
+      (user_type
+        (type_identifier)))
     (variable_declaration
       (simple_identifier))
     (getter

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -205,7 +205,9 @@ a as T.() -> Unit
   (as_expression
     (simple_identifier)
     (function_type
-      (type_identifier)
+      (receiver_type
+        (user_type
+          (type_identifier)))
       (function_type_parameters)
       (user_type
         (type_identifier)))))
@@ -228,10 +230,12 @@ a as Foo(x = "hi", y = "bar")
       (value_arguments
         (value_argument
           (simple_identifier)
-          (string_literal (string_content)))
+          (string_literal
+            (string_content)))
         (value_argument
           (simple_identifier)
-          (string_literal (string_content)))))))
+          (string_literal
+            (string_content)))))))
 
 ================================================================================
 Type constructor with trailing comma
@@ -251,10 +255,12 @@ a as Foo(x = "hi", y = "bar",)
       (value_arguments
         (value_argument
           (simple_identifier)
-          (string_literal (string_content)))
+          (string_literal
+            (string_content)))
         (value_argument
           (simple_identifier)
-          (string_literal (string_content)))))))
+          (string_literal
+            (string_content)))))))
 
 ================================================================================
 Type alias with type parameters
@@ -316,3 +322,99 @@ a as @Foo T & F
         (type_identifier))
       (user_type
         (type_identifier)))))
+
+================================================================================
+functionType Foo.Bar.() -> Unit
+================================================================================
+
+val x: Foo.Bar.() -> Unit = {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (binding_pattern_kind)
+    (variable_declaration
+      (simple_identifier)
+      (function_type
+        (receiver_type
+          (user_type
+            (type_identifier)
+            (type_identifier)))
+        (function_type_parameters)
+        (user_type
+          (type_identifier))))
+    (lambda_literal)))
+
+================================================================================
+functionType Foo.Bar.(foo: Int) -> Unit
+================================================================================
+
+val x: Foo.Bar.(foo: Int) -> Unit = {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (binding_pattern_kind)
+    (variable_declaration
+      (simple_identifier)
+      (function_type
+        (receiver_type
+          (user_type
+            (type_identifier)
+            (type_identifier)))
+        (function_type_parameters
+          (parameter
+            (simple_identifier)
+            (user_type
+              (type_identifier))))
+        (user_type
+          (type_identifier))))
+    (lambda_literal)))
+
+================================================================================
+functionType Foo.() -> Unit
+================================================================================
+
+val x: Foo.() -> Unit = {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (property_declaration
+    (binding_pattern_kind)
+    (variable_declaration
+      (simple_identifier)
+      (function_type
+        (receiver_type
+          (user_type
+            (type_identifier)))
+        (function_type_parameters)
+        (user_type
+          (type_identifier))))
+    (lambda_literal)))
+
+================================================================================
+bad: fun foo(fn: Foo.Bar.() -> Unit) {}
+================================================================================
+
+fun foo(fn: Foo.Bar.() -> Unit) {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters
+      (parameter
+        (simple_identifier)
+        (function_type
+          (receiver_type
+            (user_type
+              (type_identifier)
+              (type_identifier)))
+          (function_type_parameters)
+          (user_type
+            (type_identifier)))))
+    (function_body)))


### PR DESCRIPTION
Fixes https://github.com/fwcd/tree-sitter-kotlin/issues/153 by using receiver_type.

- I'm not too familiar with grammar-writing, so I'm unsure if my fixes here are ideal.
- `function_type` has been updated to more closely match the [official grammar for functionType](https://kotlinlang.org/spec/syntax-and-grammar.html#grammar-rule-functionType). 
- `[$.receiver_type], [$.receiver_type, $._type],` have been added to the conflicts list. Adding these conflict entries made previously error-generating Kotlin inputs non-error-generating with sensible parse trees. It's unclear if this is the best strategy for specifying the grammar.

Draft mode because this also includes changes from https://github.com/fwcd/tree-sitter-kotlin/pull/152.