### PR TITLE
Type params with trailing commas

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -286,7 +286,7 @@ module.exports = grammar({
       $._expression
     ),
 
-    type_parameters: $ => seq("<", sep1($.type_parameter, ","), ">"),
+    type_parameters: $ => seq("<", sep1($.type_parameter, ","), optional(","), ">"),
 
     type_parameter: $ => seq(
       optional($.type_parameter_modifiers),
@@ -714,7 +714,7 @@ module.exports = grammar({
       $.lambda_literal
     ),
 
-    type_arguments: $ => seq("<", sep1($.type_projection, ","), ">"),
+    type_arguments: $ => seq("<", sep1($.type_projection, ","), optional(","), ">"),
 
     value_arguments: $ => seq(
       "(",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -913,6 +913,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": ">"
         }
@@ -3566,6 +3578,18 @@
                   }
                 ]
               }
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
             }
           ]
         },

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -286,6 +286,32 @@ private typealias T<E> = Foo<E>
             (type_identifier)))))))
 
 ================================================================================
+Type alias with type parameters and trailing comma
+================================================================================
+
+typealias T<E, Q,> = Foo<E, Q,>
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (type_alias
+    (type_identifier)
+      (type_parameters
+        (type_parameter
+          (type_identifier))
+        (type_parameter
+          (type_identifier)))
+      (user_type
+        (type_identifier)
+          (type_arguments
+            (type_projection
+              (user_type
+                (type_identifier)))
+            (type_projection
+              (user_type
+                (type_identifier)))))))
+
+================================================================================
 Ampersand type
 ================================================================================
 


### PR DESCRIPTION
Supporting trailing commas in type-params and type-arguments to handle cases like:
```kotlin
typealias Foo = 
  SomeTypeWithParams<
    Int, 
    Int,
  >
```

I've added a single test, but feel free to let me know if there should be more.