### PR TITLE
Allow automatic semi-colon before in for range test

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -351,13 +351,9 @@ static bool scan_automatic_semicolon(TSLexer *lexer) {
     case 'e':
       return !scan_for_word(lexer, "lse", 3);
 
-    // Don't insert a semicolon before `in` or `instanceof`, but do insert one
-    // before an identifier or an import.
+    // Don't insert a semicolon before `instanceof`
     case 'i':
       skip(lexer);
-      if (lexer->lookahead != 'n') return true;
-      skip(lexer);
-      if (!iswalpha(lexer->lookahead)) return false;
       return !scan_for_word(lexer, "stanceof", 8);
 
     case ';':

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -88,6 +88,27 @@ sum(1, 2)
           (integer_literal))))))
 
 ================================================================================
+Check expression
+================================================================================
+
+count in 1..45
+day in 1..7
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (check_expression
+    (simple_identifier)
+    (range_expression
+      (integer_literal)
+      (integer_literal)))
+  (check_expression
+    (simple_identifier)
+    (range_expression
+      (integer_literal)
+      (integer_literal))))
+
+================================================================================
 When expression
 ================================================================================
 
@@ -95,6 +116,7 @@ val x = 1
 val y = when(x){
         1 -> true
         2 -> false
+        in 3..10 -> true
     }
 
 --------------------------------------------------------------------------------
@@ -120,6 +142,14 @@ val y = when(x){
       (when_entry
         (when_condition
           (integer_literal))
+        (control_structure_body
+          (boolean_literal)))
+      (when_entry
+        (when_condition
+          (range_test
+            (range_expression
+              (integer_literal)
+              (integer_literal))))
         (control_structure_body
           (boolean_literal))))))
 


### PR DESCRIPTION
Previously, ASI was disabled before `in`, but this breaks parsing of
when clauses with range tests. This commit removes this restriction and
only avoids insertion of a newline before `instanceof`.
