### PR TITLE
Remove suspend from builtin functions - it's a modifier keyword 

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -183,7 +183,6 @@
 		"require"
 		"requireNotNull"
 		"with"
-		"suspend"
 		"synchronized"
 ))
 


### PR DESCRIPTION
Fixes incorrect syntax highlighting for 'suspend' keyword.

Problem:
'suspend' was listed as @function.builtin but it's actually a modifier keyword, not a function. This caused wrong colors.

Changes:

highlights.scm: Removed "suspend" from builtin functions list
'suspend' is already highlighted correctly as a modifier via function_modifier and _type_modifier rules.

Example:
suspend fun fetchData() // 'suspend' is a modifier
// NOT a function like println()

Tests: 111/111 pass