### PR TITLE
Include LICENSE file in crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "bindings/rust/README.md"
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE",
   "bindings/rust/*",
   "grammar.js",
   "queries/*",


### PR DESCRIPTION
This is needed by the MIT license and required for packaging in distributions like Fedora

```bash
$ cargo package --allow-dirty --list | grep LICENSE
LICENSE
```