### PR TITLE
Remove suspend from builtin functions - it's a modifier keyword 

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -183,7 +183,6 @@
 		"require"
 		"requireNotNull"
 		"with"
-		"suspend"
 		"synchronized"
 ))
 


### PR DESCRIPTION
Rebased version of #197