### PR TITLE
Remove duplicate binary expression entries

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -664,8 +664,6 @@ module.exports = grammar({
       $.check_expression,
       $.comparison_expression,
       $.equality_expression,
-      $.comparison_expression,
-      $.equality_expression,
       $.conjunction_expression,
       $.disjunction_expression
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3154,14 +3154,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "comparison_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "equality_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "conjunction_expression"
         },
         {


### PR DESCRIPTION
Rebased version of #182 by @AlexandrosAlexiou.

Also removes the second duplicate (`equality_expression`) that was missed in the original PR.

Zero functional impact — `choice()` already handles duplicate alternatives.