### PR TITLE
Fix import list absorbing trailing multiline comments

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -233,7 +233,7 @@ static bool scan_multiline_comment(TSLexer *lexer) {
 
 static bool scan_whitespace_and_comments(TSLexer *lexer) {
   while (iswspace(lexer->lookahead)) skip(lexer);
-  return lexer->lookahead != '/';
+  return true;
 }
 
 // Test for any identifier character other than the first character.
@@ -327,7 +327,13 @@ static bool scan_automatic_semicolon(TSLexer *lexer) {
     case '?':
     case '|':
     case '&':
+      return false;
+
+    // Don't insert a semicolon before `/` (division), but do insert one before
+    // `//` (line comment) and `/*` (block comment).
     case '/':
+      skip(lexer);
+      if (lexer->lookahead == '/' || lexer->lookahead == '*') return true;
       return false;
 
     // Insert a semicolon before `--` and `++`, but not before binary `+` or `-`.
@@ -467,8 +473,6 @@ static bool scan_import_list_delimiter(TSLexer *lexer) {
       default:
         return true;
     }
-
-    return false;
   }
 }
 

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -120,3 +120,26 @@ import java.io.Path import java.io.Files
         (simple_identifier)
         (simple_identifier)
         (simple_identifier)))))
+
+================================================================================
+Import followed by multiline comment
+================================================================================
+
+import foo.bar
+
+/**
+ * Documentation
+ */
+class MyClass
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier))))
+  (multiline_comment)
+  (class_declaration
+    (type_identifier)))


### PR DESCRIPTION
## Summary
- Fixed `scan_whitespace_and_comments` returning false on `/`, which cancelled ASI before comments
- Fixed `scan_automatic_semicolon` to distinguish division `/` from comment starts `//` and `/*`
- Removed stray `return false;` in `scan_import_list_delimiter` that broke whitespace skipping loop

Multiline comments after import statements are now correctly parsed as siblings of the `import_list` node rather than being absorbed into it.

## Test plan
- [x] All existing tests pass
- [x] New test case: import followed by multiline comment and class declaration
- [x] Scanner-only change, no parser.c size impact

Fixes #173