### PR TITLE
Add tags.scm for code navigation support

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,0 +1,43 @@
+; Classes
+(class_declaration
+  (type_identifier) @name) @definition.class
+
+; Objects
+(object_declaration
+  (type_identifier) @name) @definition.class
+
+; Functions (top-level and member)
+(function_declaration
+  (simple_identifier) @name) @definition.function
+
+; Properties
+(property_declaration
+  (variable_declaration
+    (simple_identifier) @name)) @definition.constant
+
+; Enum entries
+(enum_entry
+  (simple_identifier) @name) @definition.constant
+
+; Type aliases
+(type_alias
+  (type_identifier) @name) @definition.type
+
+; Companion objects (only named ones)
+(companion_object
+  (type_identifier) @name) @definition.class
+
+; Function calls
+(call_expression
+  (simple_identifier) @name) @reference.call
+
+; Method calls via navigation
+(call_expression
+  (navigation_expression
+    (navigation_suffix
+      (simple_identifier) @name))) @reference.call
+
+; Constructor invocations (class references)
+(constructor_invocation
+  (user_type
+    (type_identifier) @name)) @reference.class

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -9,7 +9,8 @@
         "kt",
         "kts"
       ],
-      "highlights": "queries/highlights.scm"
+      "highlights": "queries/highlights.scm",
+      "tags": "queries/tags.scm"
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary
Add `queries/tags.scm` enabling `tree-sitter tags` and tools like [aider](https://aider.chat/) that rely on tags for code navigation.

### Tags defined

| Kotlin Construct | Tag Type |
|---|---|
| class, enum class | `@definition.class` |
| object declaration | `@definition.class` |
| function | `@definition.function` |
| property (val/var) | `@definition.constant` |
| enum entry | `@definition.constant` |
| type alias | `@definition.type` |
| named companion object | `@definition.class` |
| function/method call | `@reference.call` |
| constructor invocation | `@reference.class` |

### Example output
```
$ tree-sitter tags examples/Logger.kt
LOG            | constant  def (11, 4)  `val LOG = Logger()`
JULRedirector  | class     def (13, 14) `private class JULRedirector...`
publish        | function  def (14, 15) `override fun publish(record: LogRecord)`
LogLevel       | class     def (30, 11) `enum class LogLevel(val value: Int)`
NONE           | constant  def (31, 2)  `NONE(100),`
Logger         | class     def (49, 6)  `class Logger {`
...
```

## Test plan
- [x] `tree-sitter tags examples/Logger.kt` produces correct output
- [x] All existing tests still pass

Fixes #91
Fixes #158