### PR TITLE
Auto-update web-tree-sitter runtime on playground deployment

### DIFF
--- a/.github/workflows/deploy-to-github.yml
+++ b/.github/workflows/deploy-to-github.yml
@@ -56,6 +56,20 @@ jobs:
           rm -rf gh-pages/assets/tree-sitter-kotlin*
           mkdir -p "gh-pages/assets/tree-sitter-kotlin-$tag"
           cp tree-sitter-kotlin.wasm "gh-pages/assets/tree-sitter-kotlin-$tag"
+
+          echo "==> Updating web-tree-sitter runtime..."
+          TS_VERSION=$(node -p "require('./node_modules/tree-sitter-cli/package.json').version")
+          echo "tree-sitter-cli version: $TS_VERSION"
+          cd /tmp
+          npm pack "web-tree-sitter@$TS_VERSION"
+          mkdir -p wts && tar xzf web-tree-sitter-*.tgz -C wts
+          cd "$GITHUB_WORKSPACE"
+          rm -rf gh-pages/assets/web-tree-sitter-*
+          mkdir -p "gh-pages/assets/web-tree-sitter-$TS_VERSION"
+          cp /tmp/wts/package/tree-sitter.js "gh-pages/assets/web-tree-sitter-$TS_VERSION/"
+          cp /tmp/wts/package/tree-sitter.wasm "gh-pages/assets/web-tree-sitter-$TS_VERSION/"
+          sed -i "s|web-tree-sitter-[^/]*/tree-sitter\.js|web-tree-sitter-$TS_VERSION/tree-sitter.js|g" gh-pages/index.html
+
           tree gh-pages/assets
 
           echo "==> Updating version on website..."


### PR DESCRIPTION
## Summary

- Adds a step to `deploy-to-github.yml` that fetches the matching `web-tree-sitter` npm package and updates the gh-pages runtime assets automatically on each tag push
- Reads the installed `tree-sitter-cli` version, downloads the matching `web-tree-sitter` via `npm pack`, extracts `tree-sitter.js` + `tree-sitter.wasm`, and updates the asset directory and `index.html` reference

This eliminates the ABI mismatch errors described in #101 where the playground would fail with `Incompatible language version` when the bundled runtime fell behind the grammar.

> **Note:** This approach works while `tree-sitter-cli` stays at 0.24.x. At 0.25+ the `web-tree-sitter` package switched to ESM with renamed files, which will require a playground rewrite (e.g. using `tree-sitter playground --export` from CLI v0.26.1+).

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] On next tag push, confirm gh-pages gets updated `web-tree-sitter-<version>/` assets
- [ ] Confirm playground loads without version mismatch errors