### PR TITLE
fix: depend on tree-sitter/go-tree-sitter

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,7 +3,7 @@ package tree_sitter_kotlin_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_kotlin "github.com/fwcd/tree-sitter-kotlin/bindings/go"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/fwcd/tree-sitter-kotlin
 
 go 1.22
 
-require github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
+require github.com/tree-sitter/go-tree-sitter v0.24.0
+
+require github.com/mattn/go-pointer v0.0.1 // indirect


### PR DESCRIPTION
Hi! We are using your grammar @endorlabs (🙇🏻 for maintaining this!) and ran into a tricky dependency problem. I tracked it down to this grammar's dependency on `smacker/go-tree-sitter`. This library has not been maintained since the Go bindings were adopted in the upstream tree-sitter org ([link](https://github.com/tree-sitter/go-tree-sitter)).

All upstream grammars have moved to `tree-sitter/go-tree-sitter` ([example](https://github.com/tree-sitter/tree-sitter-java/blob/master/go.mod)). I propose to do the same here to stay aligned with upstream changes and keep it as easy as possible to use multiple grammars in a single project.