### PR TITLE
Fix parsing if else-branch inside when-expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -160,6 +160,10 @@ module.exports = grammar({
     // ambiguity between call_suffix and _generic_call_suffix (both can match type_arguments + args)
     [$.call_suffix, $._generic_call_suffix],
     [$._call_suffix_no_trailing_lambda, $._generic_call_suffix_no_trailing_lambda],
+
+    // prec.dynamic on the else-branch doesn't suppress GLR the way prec.right did,
+    // so shift-reduce conflicts within if_expression must be declared explicitly.
+    [$.if_expression, $.if_expression],
   ],
 
   externals: $ => [
@@ -1009,20 +1013,20 @@ module.exports = grammar({
       $._super_at
     )),
 
-    if_expression: $ => prec.right(seq(
+    if_expression: $ => seq(
       "if",
       "(", field('condition', $._expression), ")",
       choice(
-        field('consequence', $.control_structure_body),
-        seq(
+        prec.dynamic(1, seq(
           optional(field('consequence', $.control_structure_body)),
           optional(";"),
           "else",
           choice(field('alternative', $.control_structure_body), ";")
-        ),
+        )),
+        field('consequence', $.control_structure_body),
         ";"
       )
-    )),
+    ),
 
     when_subject: $ => seq(
       "(",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5046,43 +5046,35 @@
       }
     },
     "if_expression": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "if"
-          },
-          {
-            "type": "STRING",
-            "value": "("
-          },
-          {
-            "type": "FIELD",
-            "name": "condition",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
-            }
-          },
-          {
-            "type": "STRING",
-            "value": ")"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "consequence",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "control_structure_body"
-                }
-              },
-              {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PREC_DYNAMIC",
+              "value": 1,
+              "content": {
                 "type": "SEQ",
                 "members": [
                   {
@@ -5135,15 +5127,23 @@
                     ]
                   }
                 ]
-              },
-              {
-                "type": "STRING",
-                "value": ";"
               }
-            ]
-          }
-        ]
-      }
+            },
+            {
+              "type": "FIELD",
+              "name": "consequence",
+              "content": {
+                "type": "SYMBOL",
+                "name": "control_structure_body"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": ";"
+            }
+          ]
+        }
+      ]
     },
     "when_subject": {
       "type": "SEQ",
@@ -7404,6 +7404,10 @@
     [
       "_call_suffix_no_trailing_lambda",
       "_generic_call_suffix_no_trailing_lambda"
+    ],
+    [
+      "if_expression",
+      "if_expression"
     ]
   ],
   "precedences": [],

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -312,6 +312,45 @@ when (this) {
           (null_literal))))))
 
 ================================================================================
+When expression with dangling if-else
+================================================================================
+
+when (x) {
+    is State.Canceled ->
+      if(isTrue) {
+        println(42)
+      }
+    else -> {}
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier)
+            (type_identifier))))
+      (control_structure_body
+        (if_expression
+          (simple_identifier)
+          (control_structure_body
+            (statements
+              (call_expression
+                (simple_identifier)
+                (call_suffix
+                  (value_arguments
+                    (value_argument
+                      (integer_literal))))))))))
+    (when_entry
+      (control_structure_body))))
+
+
+================================================================================
 Expressions with Soft Keywords
 ================================================================================
 


### PR DESCRIPTION
The following would fail to parse:
```kotlin
when (x) {
    is State.Canceled ->
      if(isTrue) {
        println(42)
      }
    else -> {}
}
```
The problem was the the `else -> {}` branch would be taken to be part of the `if`-expression, but it should not (in this case).
