### PR TITLE
fix(scanner): resolve if-else ambiguity inside when expressions

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -286,49 +286,49 @@ static bool check_word(TSLexer *lexer, const char *word, unsigned len) {
   return !is_word_char(lexer->lookahead);
 }
 
+// Skip whitespace (space, tab, newline, CR) and comments (// and nested /* */)
+// using skip() so characters are not included in the current token.
+// Returns false if a bare '/' is encountered (not a comment), true otherwise.
+static bool skip_whitespace_and_comments(TSLexer *lexer) {
+  for (;;) {
+    while (iswspace(lexer->lookahead)) skip(lexer);
+    if (lexer->lookahead != '/') return true;
+    skip(lexer);
+    if (lexer->lookahead == '/') {
+      // Line comment — skip to end of line
+      skip(lexer);
+      while (lexer->lookahead != '\n' && lexer->lookahead != '\r' &&
+             !lexer->eof(lexer)) {
+        skip(lexer);
+      }
+    } else if (lexer->lookahead == '*') {
+      // Block comment — skip to */ (with nesting)
+      skip(lexer);
+      unsigned depth = 1;
+      while (depth > 0 && !lexer->eof(lexer)) {
+        if (lexer->lookahead == '*') {
+          skip(lexer);
+          if (lexer->lookahead == '/') { skip(lexer); depth--; }
+        } else if (lexer->lookahead == '/') {
+          skip(lexer);
+          if (lexer->lookahead == '*') { skip(lexer); depth++; }
+        } else {
+          skip(lexer);
+        }
+      }
+    } else {
+      // Bare '/' — not a comment
+      return false;
+    }
+  }
+}
+
 // After scan_for_word has matched "else", peek past optional whitespace
 // and comments for "->". If found, this is a when-entry's `else ->`,
 // not an if-else. Uses skip() so characters are not included in the
 // current token.
 static bool followed_by_arrow(TSLexer *lexer) {
-  for (;;) {
-    // Skip whitespace
-    while (lexer->lookahead == ' ' || lexer->lookahead == '\t' ||
-           lexer->lookahead == '\n' || lexer->lookahead == '\r') {
-      skip(lexer);
-    }
-    // Skip line comments
-    if (lexer->lookahead == '/') {
-      skip(lexer);
-      if (lexer->lookahead == '/') {
-        // Line comment — skip to end of line
-        while (lexer->lookahead != '\n' && lexer->lookahead != '\r' &&
-               !lexer->eof(lexer)) {
-          skip(lexer);
-        }
-        continue;
-      } else if (lexer->lookahead == '*') {
-        // Block comment — skip to */ (with nesting)
-        skip(lexer);
-        unsigned depth = 1;
-        while (depth > 0 && !lexer->eof(lexer)) {
-          if (lexer->lookahead == '*') {
-            skip(lexer);
-            if (lexer->lookahead == '/') { skip(lexer); depth--; }
-          } else if (lexer->lookahead == '/') {
-            skip(lexer);
-            if (lexer->lookahead == '*') { skip(lexer); depth++; }
-          } else {
-            skip(lexer);
-          }
-        }
-        continue;
-      }
-      // Bare '/' — not a comment, not '-'. Can't be "->".
-      return false;
-    }
-    break;
-  }
+  if (!skip_whitespace_and_comments(lexer)) return false;
   if (lexer->lookahead != '-') return false;
   skip(lexer);
   return lexer->lookahead == '>';
@@ -498,37 +498,8 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
             skip(lexer);
           }
           // Skip any whitespace and further comments after this line comment.
-          while (iswspace(lexer->lookahead)) skip(lexer);
-          while (lexer->lookahead == '/') {
-            skip(lexer);
-            if (lexer->lookahead == '/') {
-              skip(lexer);
-              while (lexer->lookahead != '\n' && lexer->lookahead != '\r' &&
-                     lexer->lookahead != 0 && !lexer->eof(lexer)) {
-                skip(lexer);
-              }
-              while (iswspace(lexer->lookahead)) skip(lexer);
-            } else if (lexer->lookahead == '*') {
-              skip(lexer);
-              unsigned depth = 1;
-              bool star = false;
-              while (depth > 0 && !lexer->eof(lexer)) {
-                if (lexer->lookahead == '*') { skip(lexer); star = true; }
-                else if (lexer->lookahead == '/') {
-                  skip(lexer);
-                  if (star) { star = false; depth--; }
-                  else { if (lexer->lookahead == '*') { depth++; skip(lexer); } star = false; }
-                } else { star = false; skip(lexer); }
-              }
-              while (iswspace(lexer->lookahead)) skip(lexer);
-            } else {
-              // A lone '/' (division) after a comment — division is a
-              // continuation operator, suppress ASI. Tree-sitter resets
-              // to P0, internal lexer matches the line comment, then the
-              // scanner is called again and sees the bare '/' directly.
-              return false;
-            }
-          }
+          // A bare '/' (division) after comments is a continuation operator.
+          if (!skip_whitespace_and_comments(lexer)) return false;
           // Now check the next real token.
           switch (lexer->lookahead) {
             case '.': case ',': case ':': case '*': case '%':

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -308,15 +308,16 @@ static bool followed_by_arrow(TSLexer *lexer) {
         }
         continue;
       } else if (lexer->lookahead == '*') {
-        // Block comment — skip to */
+        // Block comment — skip to */ (with nesting)
         skip(lexer);
-        while (!lexer->eof(lexer)) {
+        unsigned depth = 1;
+        while (depth > 0 && !lexer->eof(lexer)) {
           if (lexer->lookahead == '*') {
             skip(lexer);
-            if (lexer->lookahead == '/') {
-              skip(lexer);
-              break;
-            }
+            if (lexer->lookahead == '/') { skip(lexer); depth--; }
+          } else if (lexer->lookahead == '/') {
+            skip(lexer);
+            if (lexer->lookahead == '*') { skip(lexer); depth++; }
           } else {
             skip(lexer);
           }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -286,6 +286,53 @@ static bool check_word(TSLexer *lexer, const char *word, unsigned len) {
   return !is_word_char(lexer->lookahead);
 }
 
+// After scan_for_word has matched "else", peek past optional whitespace
+// and comments for "->". If found, this is a when-entry's `else ->`,
+// not an if-else. Uses skip() so characters are not included in the
+// current token.
+static bool followed_by_arrow(TSLexer *lexer) {
+  for (;;) {
+    // Skip whitespace
+    while (lexer->lookahead == ' ' || lexer->lookahead == '\t' ||
+           lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+      skip(lexer);
+    }
+    // Skip line comments
+    if (lexer->lookahead == '/') {
+      skip(lexer);
+      if (lexer->lookahead == '/') {
+        // Line comment — skip to end of line
+        while (lexer->lookahead != '\n' && lexer->lookahead != '\r' &&
+               !lexer->eof(lexer)) {
+          skip(lexer);
+        }
+        continue;
+      } else if (lexer->lookahead == '*') {
+        // Block comment — skip to */
+        skip(lexer);
+        while (!lexer->eof(lexer)) {
+          if (lexer->lookahead == '*') {
+            skip(lexer);
+            if (lexer->lookahead == '/') {
+              skip(lexer);
+              break;
+            }
+          } else {
+            skip(lexer);
+          }
+        }
+        continue;
+      }
+      // Bare '/' — not a comment, not '-'. Can't be "->".
+      return false;
+    }
+    break;
+  }
+  if (lexer->lookahead != '-') return false;
+  skip(lexer);
+  return lexer->lookahead == '>';
+}
+
 // Check if the current position has a visibility modifier (public, private,
 // protected, internal) followed by horizontal whitespace and "constructor".
 // Uses skip() — safe to call speculatively since no token boundary is changed.
@@ -492,7 +539,10 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
               if (lexer->lookahead == '=') return false;
               return true;
             case 'e':
-              if (scan_for_word(lexer, "lse", 3)) return false;
+              if (scan_for_word(lexer, "lse", 3)) {
+                if (followed_by_arrow(lexer)) return true;
+                return false;
+              }
               return true;
             case 'a':
               if (scan_for_word(lexer, "s", 1)) return false;
@@ -589,6 +639,7 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
             case 'e':
               lexer->mark_end(lexer);
               if (scan_for_word(lexer, "lse", 3)) {
+                if (followed_by_arrow(lexer)) return true;
                 lexer->result_symbol = MULTILINE_COMMENT;
                 return true;
               }
@@ -637,9 +688,11 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
         skip(lexer);
         return lexer->lookahead != '=';
 
-      // Don't insert a semicolon before an else
+      // Don't insert a semicolon before an else, unless it's
+      // followed by "->" (a when-entry's else, not an if-else).
       case 'e':
-        return !scan_for_word(lexer, "lse", 3);
+        if (!scan_for_word(lexer, "lse", 3)) return true;
+        return followed_by_arrow(lexer);
 
       // Don't insert a semicolon before an as
       case 'a':

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -312,6 +312,122 @@ when (this) {
           (null_literal))))))
 
 ================================================================================
+When expression with dangling if-else
+================================================================================
+
+when (x) {
+    is State.Canceled ->
+      if(isTrue) {
+        println(42)
+      }
+    else -> {}
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier)
+            (type_identifier))))
+      (control_structure_body
+        (if_expression
+          (simple_identifier)
+          (control_structure_body
+            (statements
+              (call_expression
+                (simple_identifier)
+                (call_suffix
+                  (value_arguments
+                    (value_argument
+                      (integer_literal))))))))))
+    (when_entry
+      (control_structure_body))))
+
+================================================================================
+When with if-else and else branch
+================================================================================
+
+when (x) {
+    1 -> if (a) b else c
+    else -> d
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (integer_literal))
+      (control_structure_body
+        (if_expression
+          (simple_identifier)
+          (control_structure_body
+            (simple_identifier))
+          (control_structure_body
+            (simple_identifier)))))
+    (when_entry
+      (control_structure_body
+        (simple_identifier)))))
+
+================================================================================
+When with multiple if-no-else before else branch
+================================================================================
+
+when (x) {
+    is A -> if (a) doA()
+    is B -> if (b) doB()
+    else -> doDefault()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (control_structure_body
+        (if_expression
+          (simple_identifier)
+          (control_structure_body
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments)))))))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (control_structure_body
+        (if_expression
+          (simple_identifier)
+          (control_structure_body
+            (call_expression
+              (simple_identifier)
+              (call_suffix
+                (value_arguments)))))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
 Expressions with Soft Keywords
 ================================================================================
 


### PR DESCRIPTION
## Summary

Fixes the same bug as #254: when an `if` without an `else` branch appears as a when-entry body followed by `else ->`, the parser incorrectly consumes the when's `else ->` as the if's else-branch.

```kotlin
when (x) {
    is State.Canceled ->
      if(isTrue) { println(42) }
    else -> {}  // was parsed as if's else-branch, should be a when entry
}
```

## Approach: scanner-based disambiguation

Instead of modifying `if_expression`'s grammar rule (which doubles `parser.c` from 29.5 MB to 59 MB via GLR state explosion), this fix uses the external scanner's ASI logic.

The key insight: `when`'s `else` is always followed by `->`, while `if`'s `else` never is. The scanner already suppresses ASI before `else` (to keep `if/else` together across newlines). The fix adds a `followed_by_arrow()` lookahead after matching `else` — if `->` follows (past whitespace and comments), insert ASI to terminate the preceding if-expression. Otherwise suppress ASI as before.

Modified in all three ASI paths: after newline, after line comment, and after block comment.

### vs #254

| | #254 (prec.dynamic) | This PR (scanner) |
|---|---|---|
| `parser.c` size | 59 MB (+100%) | 29.5 MB (unchanged) |
| State count | 16,860 | 9,094 (unchanged) |
| Grammar changes | Yes (removed `prec.right`, added conflict) | None |
| Scanner changes | None | `followed_by_arrow()` helper (~40 lines) |

## Test plan

- [x] All 322 corpus tests pass (319 existing + 3 new, zero regressions)
- [x] Parser generates without conflicts, parser.c size unchanged
- [x] Cross-validation: 84.9% match rate (unchanged)
- [x] Edge cases verified:
  - Classic dangling else: `if (a) if (b) x else y`
  - `if/else` inside when alongside `else ->`
  - Multiple `if`-without-else before `else ->`
  - `else ->` without spaces
  - Nested when with `else ->`
  - Comments between `else` and `->`
  - Normal `if/else` outside when (no regression)


🤖 Generated with [Claude Code](https://claude.com/claude-code)