### PR TITLE
Added guard condition in when-expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1046,13 +1046,18 @@ module.exports = grammar({
 
     when_entry: $ => seq(
       choice(
-        seq($.when_condition, repeat(seq(",", $.when_condition)), optional(",")),
+        // guard condition not allowed when multiple conditions are given
+        seq($.when_condition, repeat1(seq(",", $.when_condition)), optional(",")),
+        // optional guard condition and optional trailing comma
+        seq($.when_condition, optional($.guard_condition), optional(",")),
         "else"
       ),
       "->",
       $.control_structure_body,
       optional($._semi)
     ),
+
+    guard_condition: $ => seq("if", $._expression),
 
     when_condition: $ => choice(
       $._expression,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5244,7 +5244,7 @@
                   "name": "when_condition"
                 },
                 {
-                  "type": "REPEAT",
+                  "type": "REPEAT1",
                   "content": {
                     "type": "SEQ",
                     "members": [
@@ -5258,6 +5258,39 @@
                       }
                     ]
                   }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "when_condition"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "guard_condition"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
                 {
                   "type": "CHOICE",
@@ -5298,6 +5331,19 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "guard_condition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4313,6 +4313,177 @@
     }
   },
   {
+    "type": "guard_condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "additive_expression",
+          "named": true
+        },
+        {
+          "type": "anonymous_function",
+          "named": true
+        },
+        {
+          "type": "as_expression",
+          "named": true
+        },
+        {
+          "type": "bin_literal",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "callable_reference",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "check_expression",
+          "named": true
+        },
+        {
+          "type": "collection_literal",
+          "named": true
+        },
+        {
+          "type": "comparison_expression",
+          "named": true
+        },
+        {
+          "type": "conjunction_expression",
+          "named": true
+        },
+        {
+          "type": "disjunction_expression",
+          "named": true
+        },
+        {
+          "type": "elvis_expression",
+          "named": true
+        },
+        {
+          "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "hex_literal",
+          "named": true
+        },
+        {
+          "type": "if_expression",
+          "named": true
+        },
+        {
+          "type": "indexing_expression",
+          "named": true
+        },
+        {
+          "type": "infix_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "jump_expression",
+          "named": true
+        },
+        {
+          "type": "lambda_literal",
+          "named": true
+        },
+        {
+          "type": "long_literal",
+          "named": true
+        },
+        {
+          "type": "multiplicative_expression",
+          "named": true
+        },
+        {
+          "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "object_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_expression",
+          "named": true
+        },
+        {
+          "type": "range_expression",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "simple_identifier",
+          "named": true
+        },
+        {
+          "type": "spread_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "super_expression",
+          "named": true
+        },
+        {
+          "type": "this_expression",
+          "named": true
+        },
+        {
+          "type": "try_expression",
+          "named": true
+        },
+        {
+          "type": "unsigned_literal",
+          "named": true
+        },
+        {
+          "type": "when_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "identifier",
     "named": true,
     "fields": {},
@@ -9166,6 +9337,10 @@
       "types": [
         {
           "type": "control_structure_body",
+          "named": true
+        },
+        {
+          "type": "guard_condition",
           "named": true
         },
         {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1478,3 +1478,244 @@ someExp[x,]
     (simple_identifier)
     (indexing_suffix
       (simple_identifier))))
+
+================================================================================
+When expression with guard condition on type test
+================================================================================
+
+when (animal) {
+    is Dog if animal.isHungry -> feedDog()
+    else -> throwToy()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (guard_condition
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with guard condition on negated type test
+================================================================================
+
+when (animal) {
+    !is Cat if animal.isHungry -> feedAnother()
+    else -> throwToy()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (guard_condition
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with guard condition on range test
+================================================================================
+
+when (n) {
+    in 1..10 if n > 5 -> println("big")
+    else -> println("small")
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (range_test
+          (range_expression
+            (integer_literal)
+            (integer_literal))))
+      (guard_condition
+        (comparison_expression
+          (simple_identifier)
+          (integer_literal)))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (string_literal
+                  (string_content))))))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (string_literal
+                  (string_content))))))))))
+
+================================================================================
+When expression with guard condition on simple expression
+================================================================================
+
+when (x) {
+    0 if condition -> doSomething()
+    else -> doDefault()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (integer_literal))
+      (guard_condition
+        (simple_identifier))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with guard condition using conjunction
+================================================================================
+
+when (animal) {
+    is Animal.Cat if !animal.mouseHunter && animal.hungry -> feedCat()
+    else -> doDefault()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier)
+            (type_identifier))))
+      (guard_condition
+        (conjunction_expression
+          (prefix_expression
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier))))
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with mixed guarded and unguarded entries
+================================================================================
+
+when (animal) {
+    is Dog if animal.isHungry -> feedDog()
+    is Cat -> petCat()
+    else -> ignore()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (guard_condition
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))


### PR DESCRIPTION
Based on examples from Kotlin doc:
https://kotlinlang.org/docs/control-flow.html#guard-conditions-in-when-expressions

Handles cases like:
```kotlin
when (sub) {
  is Some.Type if condExp -> exp
}
```

@VladimirMakaev sorry that these change suggestions are more or less "one-off" for me. As I find time, I'm trying to get the Kotlin parsing to be able to handle all of our Kotlin codebase (at work), and I can only spare so much time. I hope it's useful and if not feel free to let me know .