### PR TITLE
Trailing commas function param

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1046,13 +1046,18 @@ module.exports = grammar({
 
     when_entry: $ => seq(
       choice(
-        seq($.when_condition, repeat(seq(",", $.when_condition)), optional(",")),
+        // guard condition not allowed when multiple conditions are given
+        seq($.when_condition, repeat1(seq(",", $.when_condition)), optional(",")),
+        // optional guard condition and optional trailing comma
+        seq($.when_condition, optional($.guard_condition), optional(",")),
         "else"
       ),
       "->",
       $.control_structure_body,
       optional($._semi)
     ),
+
+    guard_condition: $ => seq("if", $._expression),
 
     when_condition: $ => choice(
       $._expression,

--- a/grammar.js
+++ b/grammar.js
@@ -657,6 +657,7 @@ module.exports = grammar({
     function_type_parameters: $ => prec.left(1, seq(
       "(",
       optional(sep1(choice($.parameter, $._type), ",")),
+      optional(","),
       ")"
     )),
 
@@ -963,7 +964,7 @@ module.exports = grammar({
       ),
     ),
 
-    lambda_parameters: $ => sep1($._lambda_parameter, ","),
+    lambda_parameters: $ => seq(sep1($._lambda_parameter, ","), optional(",")),
 
     _lambda_parameter: $ => choice(
       $.variable_declaration,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5244,7 +5244,7 @@
                   "name": "when_condition"
                 },
                 {
-                  "type": "REPEAT",
+                  "type": "REPEAT1",
                   "content": {
                     "type": "SEQ",
                     "members": [
@@ -5258,6 +5258,39 @@
                       }
                     ]
                   }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "when_condition"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "guard_condition"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
                 {
                   "type": "CHOICE",
@@ -5298,6 +5331,19 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "guard_condition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2948,6 +2948,18 @@
             ]
           },
           {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
             "type": "STRING",
             "value": ")"
           }
@@ -4720,24 +4732,41 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_lambda_parameter"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_lambda_parameter"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_lambda_parameter"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_lambda_parameter"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4313,6 +4313,177 @@
     }
   },
   {
+    "type": "guard_condition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "additive_expression",
+          "named": true
+        },
+        {
+          "type": "anonymous_function",
+          "named": true
+        },
+        {
+          "type": "as_expression",
+          "named": true
+        },
+        {
+          "type": "bin_literal",
+          "named": true
+        },
+        {
+          "type": "boolean_literal",
+          "named": true
+        },
+        {
+          "type": "call_expression",
+          "named": true
+        },
+        {
+          "type": "callable_reference",
+          "named": true
+        },
+        {
+          "type": "character_literal",
+          "named": true
+        },
+        {
+          "type": "check_expression",
+          "named": true
+        },
+        {
+          "type": "collection_literal",
+          "named": true
+        },
+        {
+          "type": "comparison_expression",
+          "named": true
+        },
+        {
+          "type": "conjunction_expression",
+          "named": true
+        },
+        {
+          "type": "disjunction_expression",
+          "named": true
+        },
+        {
+          "type": "elvis_expression",
+          "named": true
+        },
+        {
+          "type": "equality_expression",
+          "named": true
+        },
+        {
+          "type": "hex_literal",
+          "named": true
+        },
+        {
+          "type": "if_expression",
+          "named": true
+        },
+        {
+          "type": "indexing_expression",
+          "named": true
+        },
+        {
+          "type": "infix_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "jump_expression",
+          "named": true
+        },
+        {
+          "type": "lambda_literal",
+          "named": true
+        },
+        {
+          "type": "long_literal",
+          "named": true
+        },
+        {
+          "type": "multiplicative_expression",
+          "named": true
+        },
+        {
+          "type": "navigation_expression",
+          "named": true
+        },
+        {
+          "type": "null_literal",
+          "named": true
+        },
+        {
+          "type": "object_literal",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "postfix_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_expression",
+          "named": true
+        },
+        {
+          "type": "range_expression",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "simple_identifier",
+          "named": true
+        },
+        {
+          "type": "spread_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "super_expression",
+          "named": true
+        },
+        {
+          "type": "this_expression",
+          "named": true
+        },
+        {
+          "type": "try_expression",
+          "named": true
+        },
+        {
+          "type": "unsigned_literal",
+          "named": true
+        },
+        {
+          "type": "when_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "identifier",
     "named": true,
     "fields": {},
@@ -9166,6 +9337,10 @@
       "types": [
         {
           "type": "control_structure_body",
+          "named": true
+        },
+        {
+          "type": "guard_condition",
           "named": true
         },
         {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1478,3 +1478,244 @@ someExp[x,]
     (simple_identifier)
     (indexing_suffix
       (simple_identifier))))
+
+================================================================================
+When expression with guard condition on type test
+================================================================================
+
+when (animal) {
+    is Dog if animal.isHungry -> feedDog()
+    else -> throwToy()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (guard_condition
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with guard condition on negated type test
+================================================================================
+
+when (animal) {
+    !is Cat if animal.isHungry -> feedAnother()
+    else -> throwToy()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (guard_condition
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with guard condition on range test
+================================================================================
+
+when (n) {
+    in 1..10 if n > 5 -> println("big")
+    else -> println("small")
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (range_test
+          (range_expression
+            (integer_literal)
+            (integer_literal))))
+      (guard_condition
+        (comparison_expression
+          (simple_identifier)
+          (integer_literal)))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (string_literal
+                  (string_content))))))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (string_literal
+                  (string_content))))))))))
+
+================================================================================
+When expression with guard condition on simple expression
+================================================================================
+
+when (x) {
+    0 if condition -> doSomething()
+    else -> doDefault()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (integer_literal))
+      (guard_condition
+        (simple_identifier))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with guard condition using conjunction
+================================================================================
+
+when (animal) {
+    is Animal.Cat if !animal.mouseHunter && animal.hungry -> feedCat()
+    else -> doDefault()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier)
+            (type_identifier))))
+      (guard_condition
+        (conjunction_expression
+          (prefix_expression
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier))))
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+When expression with mixed guarded and unguarded entries
+================================================================================
+
+when (animal) {
+    is Dog if animal.isHungry -> feedDog()
+    is Cat -> petCat()
+    else -> ignore()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (when_expression
+    (when_subject
+      (simple_identifier))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (guard_condition
+        (navigation_expression
+          (simple_identifier)
+          (navigation_suffix
+            (simple_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (when_condition
+        (type_test
+          (user_type
+            (type_identifier))))
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))
+    (when_entry
+      (control_structure_body
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -347,3 +347,21 @@ fun f() = null
    (simple_identifier)
    (function_value_parameters)
    (function_body (null_literal))))
+
+==================================
+Function block with trailing comma
+==================================
+
+{ x, -> 42 + x}
+
+----------------------------------
+
+(source_file
+  (lambda_literal
+    (lambda_parameters
+      (variable_declaration
+        (simple_identifier)))
+    (statements
+      (additive_expression
+        (integer_literal)
+        (simple_identifier)))))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -450,3 +450,23 @@ fun foo(fn: Foo.Bar.() -> Unit) {}
           (user_type
             (type_identifier)))))
     (function_body)))
+
+================================================================================
+Function type with parameters and trailing comma
+================================================================================
+
+typealias Foo = (Int, String,) -> Unit
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (type_alias
+    (type_identifier)
+    (function_type
+      (function_type_parameters
+        (user_type
+          (type_identifier))
+        (user_type
+          (type_identifier)))
+      (user_type
+        (type_identifier)))))


### PR DESCRIPTION
Allow trailing comma in function-block params
I.e. allow
```kotlin
{ x, y, ->
  ...
}
```

This PR is basically stacked on top of https://github.com/fwcd/tree-sitter-kotlin/pull/256 even though it doesn't depend on it in any way. I'll happily redo it to only include the trailing commas or redo it if the other PR gets in or change if needed?