### PR TITLE
Multi-dollar string interpolation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -172,6 +172,8 @@ module.exports = grammar({
     $.string_content,
     $._primary_constructor_keyword,
     $._import_dot,
+    $._interpolation_expression_start,
+    $._interpolation_identifier_start,
   ],
 
   extras: $ => [
@@ -937,8 +939,8 @@ module.exports = grammar({
     line_string_expression: $ => seq("${", $._expression, "}"),
 
     _interpolation: $ => choice(
-      seq("${", alias($._expression, $.interpolated_expression), "}"),
-      seq("$", alias($.simple_identifier, $.interpolated_identifier))
+      seq($._interpolation_expression_start, alias($._expression, $.interpolated_expression), "}"),
+      seq($._interpolation_identifier_start, alias($.simple_identifier, $.interpolated_identifier)),
     ),
 
     lambda_literal: $ => prec(PREC.LAMBDA_LITERAL, seq(

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -370,9 +370,7 @@
 
 ; NOTE: `interpolated_identifier`s can be highlighted in any way
 (string_literal
-	"$" @punctuation.special
 	(interpolated_identifier) @none)
 (string_literal
-	"${" @punctuation.special
 	(interpolated_expression) @none
 	"}" @punctuation.special)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4512,8 +4512,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "${"
+              "type": "SYMBOL",
+              "name": "_interpolation_expression_start"
             },
             {
               "type": "ALIAS",
@@ -4534,8 +4534,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "$"
+              "type": "SYMBOL",
+              "name": "_interpolation_identifier_start"
             },
             {
               "type": "ALIAS",
@@ -7523,6 +7523,14 @@
     {
       "type": "SYMBOL",
       "name": "_import_dot"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_interpolation_expression_start"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_interpolation_identifier_start"
     }
   ],
   "inline": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9744,14 +9744,6 @@
     "named": false
   },
   {
-    "type": "$",
-    "named": false
-  },
-  {
-    "type": "${",
-    "named": false
-  },
-  {
     "type": "%",
     "named": false
   },

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -16,6 +16,8 @@ enum TokenType {
   STRING_CONTENT,
   PRIMARY_CONSTRUCTOR_KEYWORD,
   IMPORT_DOT,
+  INTERPOLATION_EXPRESSION_START,
+  INTERPOLATION_IDENTIFIER_START,
 };
 
 /* Pretty much all of this code is taken from the Julia tree-sitter
@@ -45,16 +47,21 @@ enum TokenType {
 typedef char Delimiter;
 
 // We use a stack to keep track of the string delimiters.
+// Each entry is two bytes: [delimiter_byte, prefix_len_byte].
+// delimiter_byte: '"' for single-quoted, '"'+1 for triple-quoted.
+// prefix_len_byte: number of '$' signs required to trigger interpolation
+//   (1 for regular strings and $"...", 2 for $$"...", etc.; max 255).
 typedef Array(Delimiter) Stack;
 
-static inline void stack_push(Stack *stack, char chr, bool triple) {
-  if (stack->size >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) abort();
+static inline void stack_push(Stack *stack, char chr, bool triple, uint8_t prefix_len) {
+  if (stack->size + 1 >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) abort();
   array_push(stack, (Delimiter)(triple ? (chr + 1) : chr));
+  array_push(stack, (Delimiter)prefix_len);
 }
 
-static inline Delimiter stack_pop(Stack *stack) {
-  if (stack->size == 0) abort();
-  return array_pop(stack);
+static inline void stack_pop(Stack *stack) {
+  if (stack->size < 2) abort();
+  stack->size -= 2;
 }
 
 static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
@@ -64,49 +71,76 @@ static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 // Scanner functions
 
 static bool scan_string_start(TSLexer *lexer, Stack *stack) {
+  // Count leading '$' signs (the interpolation prefix). Capped at 255.
+  uint8_t prefix_len = 0;
+  while (lexer->lookahead == '$') {
+    advance(lexer);
+    if (prefix_len < 255) prefix_len++;
+  }
+  // Regular strings with no prefix still use a single '$' as the trigger.
+  if (prefix_len == 0) prefix_len = 1;
+
   if (lexer->lookahead != '"') return false;
   advance(lexer);
   lexer->mark_end(lexer);
   for (unsigned count = 1; count < DELIMITER_LENGTH; ++count) {
     if (lexer->lookahead != '"') {
       // It's not a triple quoted delimiter.
-      stack_push(stack, '"', false);
+      stack_push(stack, '"', false, prefix_len);
       return true;
     }
     advance(lexer);
   }
   lexer->mark_end(lexer);
-  stack_push(stack, '"', true);
+  stack_push(stack, '"', true, prefix_len);
   return true;
 }
 
-static bool scan_string_content(TSLexer *lexer, Stack *stack) {
-  if (stack->size == 0) return false;  // Stack is empty. We're not in a string.
-  Delimiter end_char = stack->contents[stack->size - 1];  // peek
-  bool is_triple = false;
+static bool scan_string_content(TSLexer *lexer, Stack *stack,
+                                const bool *valid_symbols) {
+  if (stack->size < 2) return false;  // Stack is empty. We're not in a string.
+  uint8_t prefix_len = (uint8_t)stack->contents[stack->size - 1];
+  Delimiter raw_delim = stack->contents[stack->size - 2];
+  bool is_triple = (raw_delim & 1) != 0;
+  char end_char = is_triple ? (char)(raw_delim - 1) : (char)raw_delim;
   bool has_content = false;
-  if (end_char & 1) {
-    is_triple = true;
-    end_char -= 1;
-  }
   while (lexer->lookahead) {
     if (lexer->lookahead == '$') {
-      // if we did not just start reading stuff, then we should stop
-      // lexing right here, so we can offer the opportunity to lex a
-      // interpolated identifier
+      // If we already have content, stop here so the caller can emit it
+      // before we deal with the potential interpolation.
       if (has_content) {
         lexer->result_symbol = STRING_CONTENT;
-        return has_content;
+        return true;
       }
-      // otherwise, if this is the start, determine if it is an
-      // interpolated identifier.
-      // otherwise, it's just string content, so continue
-      advance(lexer);
-      if (iswalpha(lexer->lookahead) || lexer->lookahead == '{') {
-        // this must be a string interpolation, let's
-        // fail so we parse it as such
+      // Count consecutive '$' signs up to prefix_len to determine whether
+      // this is an interpolation trigger or literal content.
+      uint8_t dollar_count = 0;
+      while (lexer->lookahead == '$' && dollar_count < prefix_len) {
+        advance(lexer);
+        dollar_count++;
+      }
+      if (dollar_count == prefix_len &&
+          (iswalpha(lexer->lookahead) || lexer->lookahead == '{')) {
+        // Exactly the right number of '$' signs, followed by an identifier
+        // start or '{'. We have already advanced past the '$' signs so emit
+        // the appropriate interpolation-start token directly here.
+        if (valid_symbols[INTERPOLATION_EXPRESSION_START] &&
+            lexer->lookahead == '{') {
+          advance(lexer);
+          lexer->mark_end(lexer);
+          lexer->result_symbol = INTERPOLATION_EXPRESSION_START;
+          return true;
+        }
+        if (valid_symbols[INTERPOLATION_IDENTIFIER_START] &&
+            iswalpha(lexer->lookahead)) {
+          lexer->mark_end(lexer);
+          lexer->result_symbol = INTERPOLATION_IDENTIFIER_START;
+          return true;
+        }
         return false;
       }
+      // Fewer '$' signs than the prefix, or not followed by alpha/'{':
+      // the dollar signs are literal string content.
       lexer->result_symbol = STRING_CONTENT;
       lexer->mark_end(lexer);
       return true;
@@ -197,6 +231,7 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack) {
   }
   return false;
 }
+
 
 static bool scan_multiline_comment(TSLexer *lexer) {
   if (lexer->lookahead != '/') return false;
@@ -924,9 +959,10 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer, con
     return scan_import_list_delimiter(lexer);
   }
 
-  // content or end
-  if (valid_symbols[STRING_CONTENT] && scan_string_content(lexer, payload)) {
-    return true;
+  // content, end, or interpolation start
+  if (valid_symbols[STRING_CONTENT] || valid_symbols[INTERPOLATION_EXPRESSION_START] ||
+      valid_symbols[INTERPOLATION_IDENTIFIER_START]) {
+    if (scan_string_content(lexer, payload, valid_symbols)) return true;
   }
 
   // a string might follow after some whitespace, so we can't lookahead

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -112,18 +112,34 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack,
         lexer->result_symbol = STRING_CONTENT;
         return true;
       }
-      // Count consecutive '$' signs up to prefix_len to determine whether
-      // this is an interpolation trigger or literal content.
-      uint8_t dollar_count = 0;
-      while (lexer->lookahead == '$' && dollar_count < prefix_len) {
+      // Kotlin 2.1 multi-dollar interpolation: in a string with prefix_len N,
+      // exactly N consecutive '$' followed by alpha/'{' triggers interpolation.
+      // Excess leading '$' signs are literal string content.
+      //
+      // Strategy: consume the first '$' and mark_end there, then count
+      // remaining '$' signs. If total > prefix_len, return STRING_CONTENT
+      // for just the first '$' (tree-sitter rewinds to mark_end). On the
+      // next scan call, the remaining dollars will be re-examined.
+      advance(lexer);
+      lexer->mark_end(lexer);
+      uint16_t additional_dollars = 0;
+      while (lexer->lookahead == '$') {
         advance(lexer);
-        dollar_count++;
+        additional_dollars++;
       }
-      if (dollar_count == prefix_len &&
+      uint16_t total_dollars = 1 + additional_dollars;
+      if (total_dollars >= prefix_len &&
           (iswalpha(lexer->lookahead) || lexer->lookahead == '{')) {
-        // Exactly the right number of '$' signs, followed by an identifier
-        // start or '{'. We have already advanced past the '$' signs so emit
-        // the appropriate interpolation-start token directly here.
+        if (total_dollars > prefix_len) {
+          // Excess: emit first '$' as literal STRING_CONTENT.
+          // mark_end is after the first '$'; tree-sitter rewinds there.
+          lexer->result_symbol = STRING_CONTENT;
+          return true;
+        }
+        // Exact match: emit interpolation start token.
+        if (additional_dollars > 0) {
+          lexer->mark_end(lexer);
+        }
         if (valid_symbols[INTERPOLATION_EXPRESSION_START] &&
             lexer->lookahead == '{') {
           advance(lexer);
@@ -133,16 +149,17 @@ static bool scan_string_content(TSLexer *lexer, Stack *stack,
         }
         if (valid_symbols[INTERPOLATION_IDENTIFIER_START] &&
             iswalpha(lexer->lookahead)) {
-          lexer->mark_end(lexer);
           lexer->result_symbol = INTERPOLATION_IDENTIFIER_START;
           return true;
         }
         return false;
       }
-      // Fewer '$' signs than the prefix, or not followed by alpha/'{':
-      // the dollar signs are literal string content.
+      // Not enough '$' signs or not followed by alpha/'{':
+      // all consumed dollars are literal string content.
+      if (additional_dollars > 0) {
+        lexer->mark_end(lexer);
+      }
       lexer->result_symbol = STRING_CONTENT;
-      lexer->mark_end(lexer);
       return true;
     }
     if (lexer->lookahead == '\\') {
@@ -1000,16 +1017,22 @@ void tree_sitter_kotlin_external_scanner_destroy(void *payload) {
 
 unsigned tree_sitter_kotlin_external_scanner_serialize(void *payload, char *buffer) {
   Stack *stack = (Stack *)payload;
-  if (stack->size > 0) {
-    // it's an undefined behavior to memcpy 0 bytes
-    memcpy(buffer, stack->contents, stack->size);
+  unsigned n = stack->size;
+  if (n > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
+    n = TREE_SITTER_SERIALIZATION_BUFFER_SIZE;
   }
-  return stack->size;
+  if (n > 0) {
+    // it's an undefined behavior to memcpy 0 bytes
+    memcpy(buffer, stack->contents, n);
+  }
+  return n;
 }
 
 void tree_sitter_kotlin_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
   Stack *stack = (Stack *)payload;
-  if (length > 0) {
+  // Stack entries are 2 bytes each (delimiter + prefix_len).
+  // Discard corrupted state with odd length.
+  if (length > 0 && length % 2 == 0) {
     array_reserve(stack, length);
     memcpy(stack->contents, buffer, length);
     stack->size = length;

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -135,6 +135,25 @@ More string interpolation
   (string_literal))
 
 ================================================================================
+Multiline string interpolation with prefix
+================================================================================
+
+$$"""
+In here we can have a verbatim $, while interpolation is triggered
+by $$x
+"""
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)
+    (interpolated_identifier)
+    (string_content)))
+
+================================================================================
 Integer literals
 ================================================================================
 

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -154,6 +154,124 @@ by $$x
     (string_content)))
 
 ================================================================================
+Single-line string interpolation with prefix
+================================================================================
+
+$$"hello $$name"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (string_content)
+    (interpolated_identifier)))
+
+================================================================================
+Expression interpolation with prefix
+================================================================================
+
+$$"value: $${x + 1}"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (string_content)
+    (interpolated_expression
+      (additive_expression
+        (simple_identifier)
+        (integer_literal)))))
+
+================================================================================
+Triple-dollar prefix interpolation
+================================================================================
+
+$$$"""triple $$$name"""
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (string_content)
+    (interpolated_identifier)))
+
+================================================================================
+Excess dollars before interpolation
+================================================================================
+
+$$"""$$$name"""
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (string_content)
+    (interpolated_identifier)))
+
+================================================================================
+Excess dollars before expression interpolation
+================================================================================
+
+$$"$$${x + 1}"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (string_content)
+    (interpolated_expression
+      (additive_expression
+        (simple_identifier)
+        (integer_literal)))))
+
+================================================================================
+Literal dollar in multi-dollar string
+================================================================================
+
+$$"literal $ and $$name"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)
+    (interpolated_identifier)))
+
+================================================================================
+Multiple interpolations in multi-dollar string
+================================================================================
+
+$$"$$a and $${b + c}"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (interpolated_identifier)
+    (string_content)
+    (interpolated_expression
+      (additive_expression
+        (simple_identifier)
+        (simple_identifier)))))
+
+================================================================================
+Nested multi-dollar strings
+================================================================================
+
+$$"$${$$"inner $$x"}"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (interpolated_expression
+      (string_literal
+        (string_content)
+        (interpolated_identifier)))))
+
+================================================================================
 Integer literals
 ================================================================================
 


### PR DESCRIPTION
In Kotlin 2.1 it is possible to have a string template like:
```kotlin
$$$"""
This is a template where $$$x denotes interpolation of "x"
"""
```

Where N dollar signs prefixed to strings indicate that N dollar signs
are needed to trigger interpolation.

This has been implemented by extending the scanner and introducing two
new external tokes:

- Storing prefix length (1–255) alongside the delimiter on the scanner
  stack (two bytes per entry instead of one)
- Scanning the prefix in scan_string_start and using it in
  scan_string_content to detect the interpolation trigger
- Replacing the grammar's literal "$" / "${" interpolation tokens with
  two new external tokens (_interpolation_expression_start /
  _interpolation_identifier_start) that consume the right number of
  dollar signs for any prefix length
- Removing the now-invalid "$" / "${" captures from highlights.scm
  (these were already dead — the anonymous nodes never appeared in the
  tree — so there is no highlighting regression)