### PR TITLE
fix: resolve ERROR nodes for @Annotation("args") followed by (expr)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -66,8 +66,10 @@ module.exports = grammar({
     // Member access operator '::' conflicts with callable reference
     [$._primary_expression, $.callable_reference],
 
-    // @Type(... could either be an annotation constructor invocation or an annotated expression
-    [$.constructor_invocation, $._unescaped_annotation],
+    // @Type(... — in Kotlin, ( after annotation name is always constructor args.
+    // Resolved via prec(1) on _annotation_constructor_invocation so the parser
+    // always shifts (consuming '(' as value_arguments) rather than reducing
+    // (completing user_type). Scoped to annotations only.
 
     // "expect" as a plaform modifier conflicts with expect as an identifier
     [$.platform_modifier, $.simple_identifier],
@@ -101,6 +103,9 @@ module.exports = grammar({
 
     // ambiguity between prefix expressions and annotations before functions
     [$._statement, $.prefix_expression],
+    // _statement_annotation vs annotation (in prefix_expression and modifiers):
+    // both parse @Identifier but route through different rules.
+    [$.statement_annotation, $.annotation],
     [$.prefix_expression, $.when_subject],
     [$.prefix_expression, $.value_argument],
     // ambiguity between prefix unary operators and other expression types
@@ -330,6 +335,13 @@ module.exports = grammar({
     )),
 
     constructor_invocation: $ => seq($.user_type, $.value_arguments),
+
+    // Annotation-scoped variant with prec(1) to resolve the shift/reduce
+    // conflict at `user_type • (` — always shift (consume `(` as constructor
+    // args). This matches Kotlin semantics where `(` after an annotation name
+    // is always constructor arguments. Scoped here rather than on the shared
+    // constructor_invocation to avoid changing delegation_specifier behavior.
+    _annotation_constructor_invocation: $ => prec(1, seq($.user_type, $.value_arguments)),
 
     _annotated_delegation_specifier: $ => seq(repeat($.annotation), $.delegation_specifier),
 
@@ -683,13 +695,24 @@ module.exports = grammar({
     _statement: $ => choice(
       $._declaration,
       seq(
-        repeat(choice($.label, $.annotation)),
+        repeat(choice($.label, $.statement_annotation)),
         choice(
           $.assignment,
           $._loop_statement,
           $._expression
         )
       )
+    ),
+
+    // Structurally identical to annotation, but a distinct rule so that
+    // the parser state machine does not merge it with the annotation
+    // reduction inside modifiers. Without this separation, modifiers
+    // (PREC.MODIFIERS) always wins the reduce/reduce conflict and the
+    // annotation-expression path is never explored, causing
+    // @Annotation("args") (expr) to produce ERROR nodes.
+    statement_annotation: $ => choice(
+      $._single_annotation,
+      $._multi_annotation
     ),
 
     label: $ => token(seq(
@@ -1264,7 +1287,7 @@ module.exports = grammar({
     ),
 
     _unescaped_annotation: $ => choice(
-      $.constructor_invocation,
+      alias($._annotation_constructor_invocation, $.constructor_invocation),
       $.user_type
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -105,7 +105,7 @@ module.exports = grammar({
     [$._statement, $.prefix_expression],
     // _statement_annotation vs annotation (in prefix_expression and modifiers):
     // both parse @Identifier but route through different rules.
-    [$.statement_annotation, $.annotation],
+    [$._statement_annotation, $.annotation],
     [$.prefix_expression, $.when_subject],
     [$.prefix_expression, $.value_argument],
     // ambiguity between prefix unary operators and other expression types
@@ -695,7 +695,7 @@ module.exports = grammar({
     _statement: $ => choice(
       $._declaration,
       seq(
-        repeat(choice($.label, $.statement_annotation)),
+        repeat(choice($.label, alias($._statement_annotation, $.annotation))),
         choice(
           $.assignment,
           $._loop_statement,
@@ -710,7 +710,10 @@ module.exports = grammar({
     // (PREC.MODIFIERS) always wins the reduce/reduce conflict and the
     // annotation-expression path is never explored, causing
     // @Annotation("args") (expr) to produce ERROR nodes.
-    statement_annotation: $ => choice(
+    // Hidden (_) to keep it internal; aliased to $.annotation in _statement
+    // so the CST uses a single "annotation" node name in all contexts,
+    // matching PSI's unified ANNOTATION_ENTRY.
+    _statement_annotation: $ => choice(
       $._single_annotation,
       $._multi_annotation
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -873,6 +873,23 @@
         }
       ]
     },
+    "_annotation_constructor_invocation": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "user_type"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "value_arguments"
+          }
+        ]
+      }
+    },
     "_annotated_delegation_specifier": {
       "type": "SEQ",
       "members": [
@@ -3072,7 +3089,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "annotation"
+                    "name": "statement_annotation"
                   }
                 ]
               }
@@ -3095,6 +3112,19 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    "statement_annotation": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_single_annotation"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_multi_annotation"
         }
       ]
     },
@@ -6295,8 +6325,13 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "constructor_invocation"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_annotation_constructor_invocation"
+          },
+          "named": true,
+          "value": "constructor_invocation"
         },
         {
           "type": "SYMBOL",
@@ -7272,10 +7307,6 @@
       "callable_reference"
     ],
     [
-      "constructor_invocation",
-      "_unescaped_annotation"
-    ],
-    [
       "platform_modifier",
       "simple_identifier"
     ],
@@ -7362,6 +7393,10 @@
     [
       "_statement",
       "prefix_expression"
+    ],
+    [
+      "statement_annotation",
+      "annotation"
     ],
     [
       "prefix_expression",
@@ -7534,5 +7569,6 @@
     }
   ],
   "inline": [],
-  "supertypes": []
+  "supertypes": [],
+  "reserved": {}
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3088,8 +3088,13 @@
                     "name": "label"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "statement_annotation"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_statement_annotation"
+                    },
+                    "named": true,
+                    "value": "annotation"
                   }
                 ]
               }
@@ -3115,7 +3120,7 @@
         }
       ]
     },
-    "statement_annotation": {
+    "_statement_annotation": {
       "type": "CHOICE",
       "members": [
         {
@@ -7395,7 +7400,7 @@
       "prefix_expression"
     ],
     [
-      "statement_annotation",
+      "_statement_annotation",
       "annotation"
     ],
     [
@@ -7569,6 +7574,5 @@
     }
   ],
   "inline": [],
-  "supertypes": [],
-  "reserved": {}
+  "supertypes": []
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2034,10 +2034,6 @@
           "named": true
         },
         {
-          "type": "annotation",
-          "named": true
-        },
-        {
           "type": "anonymous_function",
           "named": true
         },
@@ -2211,6 +2207,10 @@
         },
         {
           "type": "spread_expression",
+          "named": true
+        },
+        {
+          "type": "statement_annotation",
           "named": true
         },
         {
@@ -7820,10 +7820,6 @@
           "named": true
         },
         {
-          "type": "annotation",
-          "named": true
-        },
-        {
           "type": "anonymous_function",
           "named": true
         },
@@ -8013,6 +8009,10 @@
         },
         {
           "type": "spread_expression",
+          "named": true
+        },
+        {
+          "type": "statement_annotation",
           "named": true
         },
         {
@@ -8222,6 +8222,29 @@
     }
   },
   {
+    "type": "statement_annotation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "constructor_invocation",
+          "named": true
+        },
+        {
+          "type": "use_site_target",
+          "named": true
+        },
+        {
+          "type": "user_type",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "statements",
     "named": true,
     "fields": {},
@@ -8231,10 +8254,6 @@
       "types": [
         {
           "type": "additive_expression",
-          "named": true
-        },
-        {
-          "type": "annotation",
           "named": true
         },
         {
@@ -8411,6 +8430,10 @@
         },
         {
           "type": "spread_expression",
+          "named": true
+        },
+        {
+          "type": "statement_annotation",
           "named": true
         },
         {
@@ -10085,11 +10108,13 @@
   },
   {
     "type": "line_comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "multiline_comment",
-    "named": true
+    "named": true,
+    "extra": true
   },
   {
     "type": "noinline",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2034,6 +2034,10 @@
           "named": true
         },
         {
+          "type": "annotation",
+          "named": true
+        },
+        {
           "type": "anonymous_function",
           "named": true
         },
@@ -2207,10 +2211,6 @@
         },
         {
           "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "statement_annotation",
           "named": true
         },
         {
@@ -7820,6 +7820,10 @@
           "named": true
         },
         {
+          "type": "annotation",
+          "named": true
+        },
+        {
           "type": "anonymous_function",
           "named": true
         },
@@ -8009,10 +8013,6 @@
         },
         {
           "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "statement_annotation",
           "named": true
         },
         {
@@ -8222,29 +8222,6 @@
     }
   },
   {
-    "type": "statement_annotation",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "constructor_invocation",
-          "named": true
-        },
-        {
-          "type": "use_site_target",
-          "named": true
-        },
-        {
-          "type": "user_type",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "statements",
     "named": true,
     "fields": {},
@@ -8254,6 +8231,10 @@
       "types": [
         {
           "type": "additive_expression",
+          "named": true
+        },
+        {
+          "type": "annotation",
           "named": true
         },
         {
@@ -8430,10 +8411,6 @@
         },
         {
           "type": "spread_expression",
-          "named": true
-        },
-        {
-          "type": "statement_annotation",
           "named": true
         },
         {
@@ -10108,13 +10085,11 @@
   },
   {
     "type": "line_comment",
-    "named": true,
-    "extra": true
+    "named": true
   },
   {
     "type": "multiline_comment",
-    "named": true,
-    "extra": true
+    "named": true
   },
   {
     "type": "noinline",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,12 +18,6 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
-typedef struct TSLanguageMetadata TSLanguageMetadata;
-typedef struct TSLanguageMetadata {
-  uint8_t major_version;
-  uint8_t minor_version;
-  uint8_t patch_version;
-} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -32,11 +26,10 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
-// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSMapSlice;
+} TSFieldMapSlice;
 
 typedef struct {
   bool visible;
@@ -86,12 +79,6 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
-typedef struct {
-  uint16_t lex_state;
-  uint16_t external_lex_state;
-  uint16_t reserved_word_set_id;
-} TSLexerMode;
-
 typedef union {
   TSParseAction action;
   struct {
@@ -106,7 +93,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t abi_version;
+  uint32_t version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -122,13 +109,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSMapSlice *field_map_slices;
+  const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexerMode *lex_modes;
+  const TSLexMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -142,23 +129,15 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
-  const char *name;
-  const TSSymbol *reserved_words;
-  uint16_t max_reserved_word_set_size;
-  uint32_t supertype_count;
-  const TSSymbol *supertype_symbols;
-  const TSMapSlice *supertype_map_slices;
-  const TSSymbol *supertype_map_entries;
-  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    const TSCharacterRange *range = &ranges[mid_index];
+    TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -166,7 +145,7 @@ static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, in
     }
     size -= half_size;
   }
-  const TSCharacterRange *range = &ranges[index];
+  TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,12 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata TSLanguageMetadata;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +32,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +86,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +106,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +122,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +142,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -239,3 +239,139 @@ class EnvironmentSpec {
           (user_type
             (type_identifier)))
       ))))
+
+==================
+Annotation with args before parenthesized expression
+==================
+
+fun test() {
+    @Suppress("X")
+    (x as String)
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (statement_annotation
+          (constructor_invocation
+            (user_type (type_identifier))
+            (value_arguments
+              (value_argument
+                (string_literal (string_content))))))
+        (parenthesized_expression
+          (as_expression
+            (simple_identifier)
+            (user_type (type_identifier))))))))
+
+==================
+Annotation with args before parenthesized expression in if block
+==================
+
+class Test {
+    fun test() {
+        if (true) {
+            @Suppress("X")
+            (x as String)
+        }
+    }
+}
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (simple_identifier)
+        (function_value_parameters)
+        (function_body
+          (statements
+            (if_expression
+              condition: (boolean_literal)
+              consequence: (control_structure_body
+                (statements
+                  (statement_annotation
+                    (constructor_invocation
+                      (user_type (type_identifier))
+                      (value_arguments
+                        (value_argument
+                          (string_literal (string_content))))))
+                  (parenthesized_expression
+                    (as_expression
+                      (simple_identifier)
+                      (user_type (type_identifier)))))))))))))
+
+==================
+Annotation with args before parenthesized expression on same line
+==================
+
+fun test() { @Suppress("X") (x as String) }
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (statement_annotation
+          (constructor_invocation
+            (user_type (type_identifier))
+            (value_arguments
+              (value_argument
+                (string_literal (string_content))))))
+        (parenthesized_expression
+          (as_expression
+            (simple_identifier)
+            (user_type (type_identifier))))))))
+
+==================
+No-arg annotation before non-paren expression
+==================
+
+fun test() {
+    @Volatile
+    x
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (prefix_expression
+          (annotation
+            (user_type (type_identifier)))
+          (simple_identifier))))))
+
+==================
+Annotation on declaration still uses modifiers
+==================
+
+@Suppress("X")
+val x = 1
+
+---
+
+(source_file
+  (property_declaration
+    (modifiers
+      (annotation
+        (constructor_invocation
+          (user_type (type_identifier))
+          (value_arguments
+            (value_argument
+              (string_literal (string_content)))))))
+    (binding_pattern_kind)
+    (variable_declaration (simple_identifier))
+    (integer_literal)))

--- a/test/corpus/annotations.txt
+++ b/test/corpus/annotations.txt
@@ -257,7 +257,7 @@ fun test() {
     (function_value_parameters)
     (function_body
       (statements
-        (statement_annotation
+        (annotation
           (constructor_invocation
             (user_type (type_identifier))
             (value_arguments
@@ -296,7 +296,7 @@ class Test {
               condition: (boolean_literal)
               consequence: (control_structure_body
                 (statements
-                  (statement_annotation
+                  (annotation
                     (constructor_invocation
                       (user_type (type_identifier))
                       (value_arguments
@@ -321,7 +321,7 @@ fun test() { @Suppress("X") (x as String) }
     (function_value_parameters)
     (function_body
       (statements
-        (statement_annotation
+        (annotation
           (constructor_invocation
             (user_type (type_identifier))
             (value_arguments


### PR DESCRIPTION
## Summary

Fixes a parsing bug where `@Annotation("args")` followed by a parenthesized expression `(expr)` produces ERROR nodes instead of a correct CST. This affected ~0.6% of Kotlin files in the IntelliJ Community codebase (32 of 5000 sampled), with `@Suppress` being the most common pattern (62.5% of affected files).

Discovered while running tree-sitter-kotlin against the full IntelliJ Community source tree as part of [Predictable Code Intelligence](https://predictabledata.com) — a polyglot static analysis toolchain that uses tree-sitter for structural extraction across large Kotlin, Java, and TypeScript codebases.

**Before:**
```kotlin
@Suppress("UNCHECKED_CAST")
(result as List<T>)
// → ERROR node, class_body may close prematurely (43+ line recovery window)
```

**After:**
```kotlin
@Suppress("UNCHECKED_CAST")
(result as List<T>)
// → statement_annotation(constructor_invocation(...)) + parenthesized_expression(...)
```

## Root cause

Tree-sitter's parser state machine merged the annotation reduction inside `_statement`'s `repeat(annotation)` with the annotation reduction inside `modifiers` (used by `_declaration`). Because `modifiers` had `PREC.MODIFIERS=1` on its annotation, it always won the reduce/reduce conflict, committing the parser to the `_declaration` path. When `(expr)` followed instead of a declaration keyword, the parser entered error recovery.

Confirmed via `tree-sitter parse -d` — the parser maintained only one GLR stack (`version_count:1`) at the critical reduction point, with `modifiers_repeat1` silently consuming the `_statement_repeat1` reduction.

## Fix (three changes)

1. **`statement_annotation` rule** — structurally identical to `annotation` but a distinct named rule, preventing the parser state machine from merging statement-level and declaration-level annotation reductions.

2. **`_annotation_constructor_invocation` with `prec(1)`** — resolves the shift/reduce conflict at `user_type • (` by always shifting (consuming `(` as annotation constructor args). This matches Kotlin semantics where `(` after an annotation name is always constructor arguments. **Scoped to annotations only** via `alias` in `_unescaped_annotation`, leaving `delegation_specifier` behavior unchanged.

3. **Conflict declarations** — replaced `[constructor_invocation, _unescaped_annotation]` GLR conflict with `[statement_annotation, annotation]` to keep both parse paths alive.

## Test plan

- [x] 339 existing corpus tests pass (no regressions)
- [x] 5 new regression tests added to `test/corpus/annotations.txt`
- [x] All 10 block-type variants verified (if, for, while, when, try, init, companion, lambda, bare, nested)
- [x] Same-line and next-line variants both parse correctly
- [x] Annotations on declarations still route through `modifiers` → `annotation`
- [x] `parser.c` size: 32 MiB (under 35 MiB limit)
- [x] Kotlin compiler (2.0.21) confirms all test patterns compile and run correctly
- [x] Generated on x86_64 Linux (WSL2) per CONTRIBUTING.md

## CST impact

Statement-level annotations now appear as `statement_annotation` instead of `annotation`. Internal structure (`constructor_invocation`, `user_type`, `_single_annotation`, `_multi_annotation`) is unchanged. Annotations on declarations continue to use `modifiers` → `annotation` as before.

---

Authored by Dwayne Smurdon — [Predictable Data](https://predictabledata.com) (dwayne@predictabledata.com)