### PR TITLE
Fix newlines before "by" delegation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -177,6 +177,7 @@ module.exports = grammar({
     $._import_dot,
     $._interpolation_expression_start,
     $._interpolation_identifier_start,
+    $._by_delegation_hint,
   ],
 
   extras: $ => [
@@ -345,6 +346,7 @@ module.exports = grammar({
         $.user_type,
         $.function_type
       ),
+      optional($._by_delegation_hint),
       "by",
       // Use a restricted expression that doesn't allow trailing lambda calls
       // to avoid ambiguity with class_body in object literals.
@@ -519,7 +521,7 @@ module.exports = grammar({
       ))
     )),
 
-    property_delegate: $ => seq("by", $._expression),
+    property_delegate: $ => seq(optional($._by_delegation_hint), "by", $._expression),
 
     destructuring_declaration: $ => prec.right(seq(
       optional($.modifiers),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -919,6 +919,18 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_by_delegation_hint"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "by"
         },
@@ -2016,6 +2028,18 @@
     "property_delegate": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_by_delegation_hint"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
         {
           "type": "STRING",
           "value": "by"
@@ -7554,6 +7578,10 @@
     {
       "type": "SYMBOL",
       "name": "_interpolation_identifier_start"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_by_delegation_hint"
     }
   ],
   "inline": [],

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -685,6 +685,15 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
                 return true;
               }
               return true;
+            case 'b':
+              if (valid_symbols[BY_DELEGATION_HINT]) {
+                lexer->mark_end(lexer);
+                if (scan_for_word(lexer, "y", 1)) {
+                  lexer->result_symbol = MULTILINE_COMMENT;
+                  return true;
+                }
+              }
+              return true;
             default:
               // the original position (P0, before the comment), so the
               // ASI token is zero-width. The block comment will be

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -16,6 +16,7 @@ enum TokenType {
   IMPORT_DOT,
   INTERPOLATION_EXPRESSION_START,
   INTERPOLATION_IDENTIFIER_START,
+  BY_DELEGATION_HINT,
 };
 
 /* Pretty much all of this code is taken from the Julia tree-sitter
@@ -576,7 +577,8 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
               if (scan_for_word(lexer, "atch", 4)) return false;
               return true;
             case 'b':
-              if (scan_for_word(lexer, "y", 1)) return false;
+              if (valid_symbols[BY_DELEGATION_HINT] &&
+                  scan_for_word(lexer, "y", 1)) return false;
               return true;
             case 'f':
               if (scan_for_word(lexer, "inally", 6)) return false;
@@ -713,9 +715,12 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
         skip(lexer);
         return lexer->lookahead != '=';
 
-      // Don't insert a semicolon before 'by' (explicit delegation and property delegates)
+      // Don't insert a semicolon before 'by' in delegation contexts.
+      // Gated on BY_DELEGATION_HINT so `by` remains a usable soft-keyword
+      // identifier in non-delegation positions.
       case 'b':
-        return !scan_for_word(lexer, "y", 1);
+        return !(valid_symbols[BY_DELEGATION_HINT] &&
+                 scan_for_word(lexer, "y", 1));
 
       // Don't insert a semicolon before an else, unless it's
       // followed by "->" (a when-entry's else, not an if-else).
@@ -846,6 +851,10 @@ static bool scan_import_dot(TSLexer *lexer) {
 }
 
 bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+  // BY_DELEGATION_HINT is declared in the grammar (optional, before `by` in
+  // explicit_delegation and property_delegate) purely so it appears in
+  // valid_symbols when the parser is in a delegation context. The scanner
+  // never emits it; it's used only as a context flag in scan_automatic_semicolon.
   if (valid_symbols[AUTOMATIC_SEMICOLON]) {
     bool ret = scan_automatic_semicolon(lexer, valid_symbols);
     // if we fail to find an automatic semicolon, it's still possible that we may

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -575,6 +575,9 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
             case 'c':
               if (scan_for_word(lexer, "atch", 4)) return false;
               return true;
+            case 'b':
+              if (scan_for_word(lexer, "y", 1)) return false;
+              return true;
             case 'f':
               if (scan_for_word(lexer, "inally", 6)) return false;
               return true;
@@ -709,6 +712,10 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
       case '!':
         skip(lexer);
         return lexer->lookahead != '=';
+
+      // Don't insert a semicolon before 'by' (explicit delegation and property delegates)
+      case 'b':
+        return !scan_for_word(lexer, "y", 1);
 
       // Don't insert a semicolon before an else, unless it's
       // followed by "->" (a when-entry's else, not an if-else).

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -465,6 +465,117 @@ object AppConfig : Config by DefaultConfig {
             (string_content)))))))
 
 ================================================================================
+Object declaration with explicit delegation on next line
+================================================================================
+
+object AppConfig : Config
+by DefaultConfig {
+    override fun get(key: String) = "custom"
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (object_declaration
+    (type_identifier)
+    (delegation_specifier
+      (explicit_delegation
+        (user_type
+          (type_identifier))
+        (simple_identifier)))
+    (class_body
+      (function_declaration
+        (modifiers
+          (member_modifier))
+        (simple_identifier)
+        (function_value_parameters
+          (parameter
+            (simple_identifier)
+            (user_type
+              (type_identifier))))
+        (function_body
+          (string_literal
+            (string_content)))))))
+
+================================================================================
+Object declaration with explicit delegation, generic type, by on next line
+================================================================================
+
+object Foo : Base.Factory<Input, Output>
+by Base.Factory.create(Impl)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (object_declaration
+    (type_identifier)
+    (delegation_specifier
+      (explicit_delegation
+        (user_type
+          (type_identifier)
+          (type_identifier)
+          (type_arguments
+            (type_projection
+              (user_type
+                (type_identifier)))
+            (type_projection
+              (user_type
+                (type_identifier)))))
+        (call_expression
+          (navigation_expression
+            (navigation_expression
+              (simple_identifier)
+              (navigation_suffix
+                (simple_identifier)))
+            (navigation_suffix
+              (simple_identifier)))
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))))))
+
+================================================================================
+Object declaration with explicit delegation, line comment before by
+================================================================================
+
+object Foo : Config
+// use the default implementation
+by DefaultConfig
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (object_declaration
+    (type_identifier)
+    (delegation_specifier
+      (explicit_delegation
+        (user_type
+          (type_identifier))
+        (line_comment)
+        (simple_identifier)))))
+
+================================================================================
+Object declaration with explicit delegation, block comment before by
+:skip
+================================================================================
+
+object Foo : Config
+/* use the default implementation */
+by DefaultConfig
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (object_declaration
+    (type_identifier)
+    (delegation_specifier
+      (explicit_delegation
+        (user_type
+          (type_identifier))
+        (multiline_comment)
+        (simple_identifier)))))
+
+================================================================================
 Class with multiple delegation specifiers
 ================================================================================
 
@@ -558,6 +669,127 @@ class Example {
                               (interpolated_identifier)
                               (string_content)
                               (interpolated_identifier))))))))))))))))
+
+================================================================================
+Class with explicit delegation, by on next line
+================================================================================
+
+class Derived(b: Base) : Base
+by b
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (primary_constructor
+      (class_parameter
+        (simple_identifier)
+        (user_type
+          (type_identifier))))
+    (delegation_specifier
+      (explicit_delegation
+        (user_type
+          (type_identifier))
+        (simple_identifier)))))
+
+================================================================================
+Property delegation with by on next line
+================================================================================
+
+class Example {
+    val lazyValue: String
+    by lazy { "computed" }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (binding_pattern_kind)
+        (variable_declaration
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (property_delegate
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (annotated_lambda
+                (lambda_literal
+                  (statements
+                    (string_literal
+                      (string_content))))))))))))
+
+================================================================================
+Property delegation, line comment before by
+================================================================================
+
+class Example {
+    val lazyValue: String
+    // computed on first access
+    by lazy { "computed" }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (binding_pattern_kind)
+        (variable_declaration
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (line_comment)
+        (property_delegate
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (annotated_lambda
+                (lambda_literal
+                  (statements
+                    (string_literal
+                      (string_content))))))))))))
+
+================================================================================
+Property delegation, block comment before by
+:skip
+================================================================================
+
+class Example {
+    val lazyValue: String
+    /* computed on first access */
+    by lazy { "computed" }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (binding_pattern_kind)
+        (variable_declaration
+          (simple_identifier)
+          (user_type
+            (type_identifier)))
+        (multiline_comment)
+        (property_delegate
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (annotated_lambda
+                (lambda_literal
+                  (statements
+                    (string_literal
+                      (string_content))))))))))))
 
 ================================================================================
 Properties

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -556,7 +556,6 @@ by DefaultConfig
 
 ================================================================================
 Object declaration with explicit delegation, block comment before by
-:skip
 ================================================================================
 
 object Foo : Config
@@ -759,7 +758,6 @@ class Example {
 
 ================================================================================
 Property delegation, block comment before by
-:skip
 ================================================================================
 
 class Example {

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -948,3 +948,32 @@ catch (e: Error) { }
       (simple_identifier)
       (user_type
         (type_identifier)))))
+
+=========================================================================================
+Block comments between standalone identifiers starting with continuation-keyword letters
+:skip
+=========================================================================================
+
+fun doo() {
+/**/
+e
+/**/
+a
+/**/
+w
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (multiline_comment)
+      (statements
+        (simple_identifier)
+        (multiline_comment)
+        (simple_identifier)
+        (multiline_comment)
+        (simple_identifier)))))

--- a/test/corpus/soft_keywords.txt
+++ b/test/corpus/soft_keywords.txt
@@ -30,3 +30,153 @@ fun foo() {
       (simple_identifier)
       (indexing_suffix
         (integer_literal))))))))
+
+================================================================================
+by as a standalone identifier expression statement
+================================================================================
+
+fun foo() {
+  val by = 1
+  println(by)
+  by
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (property_declaration
+          (binding_pattern_kind)
+          (variable_declaration
+            (simple_identifier))
+          (integer_literal))
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))
+        (simple_identifier)))))
+
+================================================================================
+by as receiver of a navigation expression after a newline
+================================================================================
+
+fun foo() {
+  val x = doSomething()
+  by.let { it }
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (property_declaration
+          (binding_pattern_kind)
+          (variable_declaration
+            (simple_identifier))
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments))))
+        (call_expression
+          (navigation_expression
+            (simple_identifier)
+            (navigation_suffix
+              (simple_identifier)))
+          (call_suffix
+            (annotated_lambda
+              (lambda_literal
+                (statements
+                  (simple_identifier))))))))))
+
+================================================================================
+by as a function call after a newline (silent misparse on branch)
+================================================================================
+
+fun foo() {
+  val x = 1
+  by()
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (property_declaration
+          (binding_pattern_kind)
+          (variable_declaration
+            (simple_identifier))
+          (integer_literal))
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))))))
+
+================================================================================
+by as a function call with arg after a newline (silent misparse on branch)
+================================================================================
+
+fun foo() {
+  val a: Int = 1
+  by(a)
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (property_declaration
+          (binding_pattern_kind)
+          (variable_declaration
+            (simple_identifier)
+            (user_type
+              (type_identifier)))
+          (integer_literal))
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments
+              (value_argument
+                (simple_identifier)))))))))
+
+================================================================================
+by as left operand of an additive expression after a newline (silent misparse on branch)
+================================================================================
+
+fun foo() {
+  someFunc()
+  by + 1
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (call_expression
+          (simple_identifier)
+          (call_suffix
+            (value_arguments)))
+        (additive_expression
+          (simple_identifier)
+          (integer_literal))))))


### PR DESCRIPTION
Fix a problem where any newline between a delegation source and the "by" keyword inserted an unwanted ASI causing parse errors for things like

    class Derived(b: Base) : Base
    by b

Instead the scanner now detects "by"s and tries to prevent ASI.

There is still a problem when block comments are used, as in:

    object Foo : Config
    /* use the default implementation */
    by DefaultConfig

I've added tests for these cases, but annotated with :skip to prevent CI passing.

I've also realized there is a similar problem with block-comments even without the "by" delegation as in:

    fun doo() {
      /**/
      e
      /**/
      a
      /**/
      w
    }

I've added a test for this but also :skip annotated it.