### PR TITLE
"?." is one token without whitespace

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -170,7 +170,6 @@ module.exports = grammar({
   externals: $ => [
     $._automatic_semicolon,
     $._import_list_delimiter,
-    $.safe_nav,
     $.multiline_comment,
     $._string_start,
     $._string_end,
@@ -1154,7 +1153,7 @@ module.exports = grammar({
 
     _postfix_unary_operator: $ => choice("++", "--", "!!"),
 
-    _member_access_operator: $ => choice(".", "::", alias($.safe_nav, '?.')),
+    _member_access_operator: $ => choice(".", "::", "?."),
 
     _postfix_unary_suffix: $ => choice(
       $._postfix_unary_operator,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5869,12 +5869,7 @@
           "value": "::"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "safe_nav"
-          },
-          "named": false,
+          "type": "STRING",
           "value": "?."
         }
       ]
@@ -7535,10 +7530,6 @@
     {
       "type": "SYMBOL",
       "name": "_import_list_delimiter"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "safe_nav"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -9,7 +9,6 @@
 enum TokenType {
   AUTOMATIC_SEMICOLON,
   IMPORT_LIST_DELIMITER,
-  SAFE_NAV,
   MULTILINE_COMMENT,
   STRING_START,
   STRING_END,
@@ -802,30 +801,6 @@ static bool scan_automatic_semicolon(TSLexer *lexer, const bool *valid_symbols) 
   }
 }
 
-static bool scan_safe_nav(TSLexer *lexer) {
-  lexer->result_symbol = SAFE_NAV;
-  lexer->mark_end(lexer);
-
-  // skip white space
-  if (!scan_whitespace_and_comments(lexer))
-    return false;
-
-  if (lexer->lookahead != '?')
-    return false;
-
-  advance(lexer);
-
-  if (!scan_whitespace_and_comments(lexer))
-    return false;
-
-  if (lexer->lookahead != '.')
-    return false;
-
-  advance(lexer);
-  lexer->mark_end(lexer);
-  return true;
-}
-
 static bool scan_line_sep(TSLexer *lexer) {
   // Line Seps: [ CR, LF, CRLF ]
   int state = 0;
@@ -938,10 +913,6 @@ static bool scan_import_dot(TSLexer *lexer) {
 bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
   if (valid_symbols[AUTOMATIC_SEMICOLON]) {
     bool ret = scan_automatic_semicolon(lexer, valid_symbols);
-    if (!ret && valid_symbols[SAFE_NAV] && lexer->lookahead == '?') {
-      return scan_safe_nav(lexer);
-    }
-
     // if we fail to find an automatic semicolon, it's still possible that we may
     // want to lex a string or comment later
     if (ret) return ret;
@@ -993,10 +964,6 @@ bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer, con
 
   if (valid_symbols[MULTILINE_COMMENT] && scan_multiline_comment(lexer)) {
     return true;
-  }
-
-  if (valid_symbols[SAFE_NAV]) {
-    return scan_safe_nav(lexer);
   }
 
   return false;

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -181,6 +181,7 @@ fun main() {
           (call_expression
             (navigation_expression
               (simple_identifier)
+              (line_comment)
               (navigation_suffix
                 (simple_identifier)))
             (call_suffix

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -48,43 +48,10 @@ Safe Navigation
 ================================================================================
 
 a?.bar()
-a? .bar()
-a? . bar()
-a?
-  .bar()
-a ? . bar()
 
 --------------------------------------------------------------------------------
 
 (source_file
-  (call_expression
-    (navigation_expression
-      (simple_identifier)
-      (navigation_suffix
-        (simple_identifier)))
-    (call_suffix
-      (value_arguments)))
-  (call_expression
-    (navigation_expression
-      (simple_identifier)
-      (navigation_suffix
-        (simple_identifier)))
-    (call_suffix
-      (value_arguments)))
-  (call_expression
-    (navigation_expression
-      (simple_identifier)
-      (navigation_suffix
-        (simple_identifier)))
-    (call_suffix
-      (value_arguments)))
-  (call_expression
-    (navigation_expression
-      (simple_identifier)
-      (navigation_suffix
-        (simple_identifier)))
-    (call_suffix
-      (value_arguments)))
   (call_expression
     (navigation_expression
       (simple_identifier)

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -347,6 +347,7 @@ val x = foo
     (call_expression
       (navigation_expression
         (simple_identifier)
+        (line_comment)
         (navigation_suffix
           (simple_identifier)))
       (call_suffix


### PR DESCRIPTION
The following isn't valid Kotlin:

```kotlin
x ? . y
```

Basically reverts 3cac8ef which added ?. as an external token that allows spaces between the "?" and ".".