### PR TITLE
Fix modifier-led class parsing before adjacent declarations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -265,7 +265,7 @@ module.exports = grammar({
     // Classes
     // ==========
 
-    class_declaration: $ => prec.right(choice(
+    class_declaration: $ => prec.dynamic(1, prec.right(choice(
       seq(
         optional($.modifiers),
         choice("class", seq(optional("fun"), "interface")),
@@ -286,7 +286,7 @@ module.exports = grammar({
         optional($.type_constraints),
         optional($.enum_class_body)
       )
-    )),
+    ))),
 
     primary_constructor: $ => seq(
       optional(seq(optional($.modifiers), $._primary_constructor_keyword)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -340,240 +340,244 @@
       ]
     },
     "class_declaration": {
-      "type": "PREC_RIGHT",
-      "value": 0,
+      "type": "PREC_DYNAMIC",
+      "value": 1,
       "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "modifiers"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "class"
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "fun"
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "interface"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "simple_identifier"
+        "type": "PREC_RIGHT",
+        "value": 0,
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "modifiers"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 },
-                "named": true,
-                "value": "type_identifier"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "type_parameters"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "primary_constructor"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ":"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_delegation_specifiers"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "type_constraints"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "class_body"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "modifiers"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "STRING",
-                "value": "enum"
-              },
-              {
-                "type": "STRING",
-                "value": "class"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "simple_identifier"
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "class"
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "fun"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "interface"
+                        }
+                      ]
+                    }
+                  ]
                 },
-                "named": true,
-                "value": "type_identifier"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "SYMBOL",
-                    "name": "type_parameters"
+                    "name": "simple_identifier"
                   },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
+                  "named": true,
+                  "value": "type_identifier"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_parameters"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "primary_constructor"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ":"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_delegation_specifiers"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_constraints"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "class_body"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "modifiers"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "enum"
+                },
+                {
+                  "type": "STRING",
+                  "value": "class"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
                     "type": "SYMBOL",
-                    "name": "primary_constructor"
+                    "name": "simple_identifier"
                   },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ":"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_delegation_specifiers"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "type_constraints"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "enum_class_body"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+                  "named": true,
+                  "value": "type_identifier"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_parameters"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "primary_constructor"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ":"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_delegation_specifiers"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "type_constraints"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "enum_class_body"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
       }
     },
     "primary_constructor": {

--- a/test/corpus/adjacent_modifier_classes.txt
+++ b/test/corpus/adjacent_modifier_classes.txt
@@ -1,0 +1,156 @@
+================================================================================
+Isolated internal open class control
+================================================================================
+
+internal open class InternalBase {
+    open fun internalWork(): InternalResult = InternalResult()
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (modifiers
+          (inheritance_modifier))
+        (simple_identifier)
+        (function_value_parameters)
+        (user_type
+          (type_identifier))
+        (function_body
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments))))))))
+
+================================================================================
+Adjacent internal classes preserve class declarations
+================================================================================
+
+package com.fixture.core.internal
+
+internal open class InternalBase {
+    open fun internalWork(): InternalResult = InternalResult()
+}
+
+internal class InternalResult {
+    fun done() {}
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_header
+    (identifier
+      (simple_identifier)
+      (simple_identifier)
+      (simple_identifier)
+      (simple_identifier)))
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (modifiers
+          (inheritance_modifier))
+        (simple_identifier)
+        (function_value_parameters)
+        (user_type
+          (type_identifier))
+        (function_body
+          (call_expression
+            (simple_identifier)
+            (call_suffix
+              (value_arguments)))))))
+  (class_declaration
+    (modifiers
+      (visibility_modifier))
+    (type_identifier)
+    (class_body
+      (function_declaration
+        (simple_identifier)
+        (function_value_parameters)
+        (function_body)))))
+
+================================================================================
+Modifier-led class followed by unmodified class
+================================================================================
+
+internal open class First {}
+class Second {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body))
+  (class_declaration
+    (type_identifier)
+    (class_body)))
+
+================================================================================
+Comment and annotation between modifier-led classes
+================================================================================
+
+internal open class First {}
+// declaration boundary
+@Marker internal class Second {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body))
+  (line_comment)
+  (class_declaration
+    (modifiers
+      (annotation
+        (user_type
+          (type_identifier)))
+      (visibility_modifier))
+    (type_identifier)
+    (class_body)))
+
+================================================================================
+Several adjacent modifier-led classes
+================================================================================
+
+internal open class First {}
+internal class Second {}
+private final class Third {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body))
+  (class_declaration
+    (modifiers
+      (visibility_modifier))
+    (type_identifier)
+    (class_body))
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body)))


### PR DESCRIPTION
Addresses #277 

## Summary

Modifier-led Kotlin classes can be misparsed as infix expressions when they are followed by an adjacent class declaration. The malformed tree can be error-free, which causes downstream syntax-tree consumers to accept a class that was never represented as a `class_declaration`.

This PR gives `class_declaration` a small dynamic precedence preference while preserving its existing right precedence. The change makes the complete class interpretation win when Tree-sitter retains competing parses at the adjacent declaration boundary.

## Example

The following valid Kotlin source previously parsed the first declaration as an `infix_expression` containing a `lambda_literal`:

```kotlin
package com.fixture.core.internal

internal open class InternalBase {
    open fun internalWork(): InternalResult = InternalResult()
}

internal class InternalResult {
    fun done() {}
}
```

The first declaration now produces a `class_declaration`, and `internalWork()` remains owned by `InternalBase`.

## Implementation

The existing rule:

```javascript
class_declaration: $ => prec.right(choice(
  // existing class and enum-class alternatives
)),
```

is now:

```javascript
class_declaration: $ => prec.dynamic(1, prec.right(choice(
  // existing class and enum-class alternatives unchanged
))),
```

`prec.right` is unchanged and continues to provide the rule's existing associativity/static conflict behavior. `prec.dynamic(1)` adds only a runtime preference among competing completed parses. It does not globally raise modifier precedence, change tokenization, or change the accepted Kotlin syntax.

The generated `src/grammar.json` and `src/parser.c` are included. Generated changes are limited to the dynamic-precedence values on `class_declaration` reductions. `src/node-types.json` and `src/scanner.c` are unchanged.

## Regression coverage

Added `test/corpus/adjacent_modifier_classes.txt` with five cases:

1. Isolated `internal open class` control.
2. Two adjacent modifier-led classes.
3. Modifier-led class followed by an unmodified class.
4. Comment and annotation between modifier-led classes.
5. Several adjacent modifier-led classes.

## Verification

- `npm test`: 364/364 grammar cases pass.
- `npm run cross-validate:test`: 92/92 tests pass.
- `npm run cross-validate`: 107 MATCH, 19 MISMATCH, 102 TS_PARSE_ERROR; no negative validation delta was introduced.
- `cargo test`: passes.