### PR TITLE
Prefer class and object declarations over infix expressions

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -564,13 +564,13 @@ module.exports = grammar({
 
     parameter: $ => seq($.simple_identifier, ":", $._type),
 
-    object_declaration: $ => prec.right(seq(
+    object_declaration: $ => prec.dynamic(1, prec.right(seq(
       optional($.modifiers),
       "object",
       alias($.simple_identifier, $.type_identifier),
       optional(seq(":", $._delegation_specifiers)),
       optional($.class_body)
-    )),
+    ))),
 
     secondary_constructor: $ => seq(
       optional($.modifiers),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2355,70 +2355,74 @@
       ]
     },
     "object_declaration": {
-      "type": "PREC_RIGHT",
-      "value": 0,
+      "type": "PREC_DYNAMIC",
+      "value": 1,
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "modifiers"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "object"
-          },
-          {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "simple_identifier"
+        "type": "PREC_RIGHT",
+        "value": 0,
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "modifiers"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
-            "named": true,
-            "value": "type_identifier"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ":"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_delegation_specifiers"
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
+            {
+              "type": "STRING",
+              "value": "object"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "SYMBOL",
-                "name": "class_body"
+                "name": "simple_identifier"
               },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
+              "named": true,
+              "value": "type_identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ":"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_delegation_specifiers"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "class_body"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        }
       }
     },
     "secondary_constructor": {

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -1101,3 +1101,67 @@ interface Foo<A, B> : ((T, A?) -> B?)
           (user_type
             (type_identifier))
           (quest))))))
+
+================================================================================
+Class with several modifiers followed by another declaration
+================================================================================
+
+internal open class First {}
+class Second {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body))
+  (class_declaration
+    (type_identifier)
+    (class_body)))
+
+================================================================================
+Class with several annotations followed by another declaration
+================================================================================
+
+@Component
+@ConfigurationProperties(prefix = "app")
+class First {
+    var url: String? = null
+}
+
+class Second {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (modifiers
+      (annotation
+        (user_type
+          (type_identifier)))
+      (annotation
+        (constructor_invocation
+          (user_type
+            (type_identifier))
+          (value_arguments
+            (value_argument
+              (simple_identifier)
+              (string_literal
+                (string_content)))))))
+    (type_identifier)
+    (class_body
+      (property_declaration
+        (binding_pattern_kind)
+        (variable_declaration
+          (simple_identifier)
+          (nullable_type
+            (user_type
+              (type_identifier))
+            (quest)))
+        (null_literal))))
+  (class_declaration
+    (type_identifier)
+    (class_body)))

--- a/test/corpus/objects.txt
+++ b/test/corpus/objects.txt
@@ -99,3 +99,23 @@ val obj = object : Thread {
         (user_type
           (type_identifier)))
       (class_body))))
+
+================================================================================
+Object with several modifiers followed by another declaration
+================================================================================
+
+internal open object First {}
+class Second {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (object_declaration
+    (modifiers
+      (visibility_modifier)
+      (inheritance_modifier))
+    (type_identifier)
+    (class_body))
+  (class_declaration
+    (type_identifier)
+    (class_body)))


### PR DESCRIPTION
Fixes #277.

## The problem

A declaration led by more than one modifier can be parsed as a top-level `infix_expression`, with the declaration body captured as a `lambda_literal`. The trigger is two conditions together: **two or more modifiers** on the declaration, and **another declaration following it**. Either one alone parses correctly, which is why short fixtures that end on the construct under test do not catch it.

```kotlin
internal open class First {}
class Second {}
```

`First` is not a `class_declaration` in the resulting tree. The tree contains no `ERROR` node, so consumers that only check for parse errors accept it. Annotations are modifiers too, so the same shape appears in ordinary framework code:

```kotlin
@Component
@ConfigurationProperties(prefix = "app")
class First {
    var url: String? = null
}

class Second {}
```

`object` declarations are affected the same way; `fun`, `val` and `typealias` are not, which is why this only touches the two rules.

## The fix

Both readings are legitimate parses of the same input — the grammar already declares conflicts between statements and prefix expressions — so the parser is choosing between two complete parses rather than recovering from an error. That makes it a dynamic-precedence decision, and both alternatives currently sit at 0.

Giving `class_declaration` and `object_declaration` a dynamic precedence of 1 makes the declaration win against the expression rules it competes with.

## Verification

- Existing corpus: 359 tests, unchanged and all passing.
- Three cases added to `test/corpus/`, covering modifier-led classes, annotation-led classes, and modifier-led objects. Two of the three fail on `main` without the grammar change; the annotation-led class case passes on `main` today and is added as a regression guard, since it is the same ambiguity and regressed in earlier revisions.
- `src/parser.c` regenerated on x86_64 Linux with the CLI from `npm install` (0.24.7). Size is unchanged at 32.2 MiB, within the 35 MiB CI limit.