### PR TITLE
Ignore local .claude/ config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tools/cross-validation/fixtures/
 
 # Generated cross-validation report (regenerated via npm run cross-validate)
 tools/cross-validation/report.md
+
+# Claude Code local config
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so per-developer [Claude Code](https://claude.com/claude-code) configuration and slash commands stay local and are not committed to the repo.

No functional changes to the grammar, parser, or tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)